### PR TITLE
Avoid the need for the TemplateHaskell extension

### DIFF
--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -1,9 +1,4 @@
 {-# Language CPP, DeriveGeneric, DeriveDataTypeable #-}
-#if __GLASGOW_HASKELL__ >= 801
-{-# Language TemplateHaskellQuotes #-}
-#else
-{-# Language TemplateHaskell #-}
-#endif
 
 {-|
 Module      : Language.Haskell.TH.Datatype
@@ -97,6 +92,7 @@ import           Data.Maybe (fromMaybe)
 import           Control.Monad (foldM)
 import           GHC.Generics (Generic)
 import           Language.Haskell.TH
+import           Language.Haskell.TH.Datatype.Internal
 import           Language.Haskell.TH.Lib (arrowK) -- needed for th-2.4
 
 #if !MIN_VERSION_base(4,8,0)
@@ -657,12 +653,12 @@ classPred =
 -- arguments to the equality constraint if successful.
 asEqualPred :: Pred -> Maybe (Type,Type)
 #if MIN_VERSION_template_haskell(2,10,0)
-asEqualPred (EqualityT `AppT` x `AppT` y)               = Just (x,y)
-asEqualPred (ConT eq   `AppT` x `AppT` y) | eq == ''(~) = Just (x,y)
+asEqualPred (EqualityT `AppT` x `AppT` y)                    = Just (x,y)
+asEqualPred (ConT eq   `AppT` x `AppT` y) | eq == eqTypeName = Just (x,y)
 #else
-asEqualPred (EqualP            x        y)              = Just (x,y)
+asEqualPred (EqualP            x        y)                   = Just (x,y)
 #endif
-asEqualPred _                                           = Nothing
+asEqualPred _                                                = Nothing
 
 -- | Match a 'Pred' representing a class constraint.
 -- Returns the classname and parameters if successful.
@@ -670,8 +666,8 @@ asClassPred :: Pred -> Maybe (Name, [Type])
 #if MIN_VERSION_template_haskell(2,10,0)
 asClassPred t =
   case decomposeType t of
-    ConT f :| xs | f /= ''(~) -> Just (f,xs)
-    _                         -> Nothing
+    ConT f :| xs | f /= eqTypeName -> Just (f,xs)
+    _                              -> Nothing
 #else
 asClassPred (ClassP f xs) = Just (f,xs)
 asClassPred _             = Nothing

--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -1,0 +1,16 @@
+{-|
+Module      : Language.Haskell.TH.Datatype.Internal
+Description : Backwards-compatible interface to reified information about datatypes.
+Copyright   : Eric Mertens 2017
+License     : ISC
+Maintainer  : emertens@gmail.com
+
+Internal Template Haskell 'Name's.
+
+-}
+module Language.Haskell.TH.Datatype.Internal where
+
+import Language.Haskell.TH.Syntax
+
+eqTypeName :: Name
+eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -26,7 +26,6 @@ source-repository head
 library
   exposed-modules:     Language.Haskell.TH.Datatype
   other-modules:       Language.Haskell.TH.Datatype.Internal
-                       Paths_th_abstraction
   build-depends:       base             >=4.5   && <5,
                        ghc-prim,
                        template-haskell >=2.7   && <2.13,

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -25,6 +25,8 @@ source-repository head
 
 library
   exposed-modules:     Language.Haskell.TH.Datatype
+  other-modules:       Language.Haskell.TH.Datatype.Internal
+                       Paths_th_abstraction
   build-depends:       base             >=4.5   && <5,
                        ghc-prim,
                        template-haskell >=2.7   && <2.13,


### PR DESCRIPTION
A goal of some libraries (including `lens`) is to compile without issue on stage-1 and cross-compilers, but to do this, one must diligently avoid the use of the `TemplateHaskell` extension. This achieves that goal by manually constructing the `(~)` Template Haskell `Name` instead of quoting it.

This isn't strictly necessary on GHC 8.0 and later, since they have `TemplateHaskellQuotes`, but the change was simple enough, so I decided to just do it for all GHCs.

I factored out the `(~)` `Name` into an internal module in case we ever need to add more `Name`s in the future.