### PR TITLE
Fix #1 (take two)

### DIFF
--- a/test/Harness.hs
+++ b/test/Harness.hs
@@ -38,7 +38,7 @@ equateDI dat1 dat2 =
      let sub = Map.fromList (zip (freeVariables (datatypeVars dat2))
                                  (map VarT (freeVariables (datatypeVars dat1))))
 
-     check "datatypeContext" id
+     zipWithM_ (equateCxt "datatypeContext")
        (datatypeContext dat1)
        (applySubstitution sub (datatypeContext dat2))
 
@@ -50,6 +50,11 @@ equateDI dat1 dat2 =
        (datatypeCons dat1)
        (applySubstitution sub (datatypeCons dat2))
 
+equateCxt :: String -> Pred -> Pred -> Either String ()
+equateCxt lbl pred1 pred2 =
+  do check (lbl ++ " class")    asClassPred pred1 pred2
+     check (lbl ++ " equality") asEqualPred pred1 pred2
+
 -- | If the arguments are equal up to renaming return @'Right' ()@,
 -- otherwise return a string exlaining the mismatch.
 equateCI :: ConstructorInfo -> ConstructorInfo -> Either String ()
@@ -60,7 +65,7 @@ equateCI con1 con2 =
      let sub = Map.fromList (zip (map tvName (constructorVars con2))
                                  (map VarT (map tvName (constructorVars con1))))
 
-     check "constructorContext" id
+     zipWithM_ (equateCxt "constructorContext")
         (constructorContext con1)
         (applySubstitution sub (constructorContext con2))
 


### PR DESCRIPTION
An improvement upon #4. This fixes the eta-reduction bug for data families encountered on GHC 7.6 and 7.8, and properly takes into account `PolyKinds` and `GADTs`.

This approach differs from the current one in that we don't take type variables from the _constructor_ type's `TyVarBndr`s anymore. Instead, we take them from the _parent data family_ `TyVarBndr`s, and do the appropriate alpha-renaming for each constructor. This has the downside that the extra type variables might have different names than they otherwise would have, but this is the only approach that is guaranteed to work in the presence of GADTs, which can yield constructor types with more/fewer `TyVarBndr`s than the data family instance itself.

Fixes #1.