### PR TITLE
Fix #16

### DIFF
--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -14,3 +14,7 @@ import Language.Haskell.TH.Syntax
 
 eqTypeName :: Name
 eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"
+
+-- This is only needed for GHC 7.6-specific bug
+starKindName :: Name
+starKindName = mkNameG_tc "ghc-prim" "GHC.Prim" "*"


### PR DESCRIPTION
By applying a substitution pass for the eta-reduced kind variables. This requires me combining two previously separate passes into one, but oh well.

Along the way, I refactored the test suite so that it does not strip off kind signatures (which is why this bug slipped through to begin with).