### PR TITLE
Make it build with GHC 7.0/7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ matrix:
     - compiler: "ghc-7.0.4"
       env: BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.0.4], sources: [hvr-ghc]}}
+    - compiler: "ghc-7.2.2"
+      env: BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-7.4.2"
       env: BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.4.2], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-7.0.4"
+      env: BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.0.4], sources: [hvr-ghc]}}
     - compiler: "ghc-7.4.2"
       env: BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.4.2], sources: [hvr-ghc]}}

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -1,7 +1,7 @@
 {-# Language CPP, DeriveDataTypeable #-}
 
 #if MIN_VERSION_base(4,4,0)
-#define HAS_GENERIC
+#define HAS_GENERICS
 {-# Language DeriveGeneric #-}
 #endif
 
@@ -95,10 +95,13 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe
 import           Control.Monad (foldM)
-import           GHC.Generics (Generic)
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Datatype.Internal
 import           Language.Haskell.TH.Lib (arrowK, starK) -- needed for th-2.4
+
+#ifdef HAS_GENERICS
+import           GHC.Generics (Generic)
+#endif
 
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative (Applicative(..), (<$>))
@@ -119,7 +122,7 @@ data DatatypeInfo = DatatypeInfo
   , datatypeCons    :: [ConstructorInfo] -- ^ Normalize constructor information
   }
   deriving (Show, Eq, Typeable, Data
-#ifdef HAS_GENERIC
+#ifdef HAS_GENERICS
            ,Generic
 #endif
            )
@@ -131,7 +134,7 @@ data DatatypeVariant
   | DataInstance    -- ^ Type declared with @data instance@
   | NewtypeInstance -- ^ Type declared with @newtype instance@
   deriving (Show, Read, Eq, Ord, Typeable, Data
-#ifdef HAS_GENERIC
+#ifdef HAS_GENERICS
            ,Generic
 #endif
            )
@@ -146,7 +149,7 @@ data ConstructorInfo = ConstructorInfo
   , constructorVariant :: ConstructorVariant -- ^ Extra information
   }
   deriving (Show, Eq, Typeable, Data
-#ifdef HAS_GENERIC
+#ifdef HAS_GENERICS
            ,Generic
 #endif
            )
@@ -158,7 +161,7 @@ data ConstructorVariant
                              --   declared infix
   | RecordConstructor [Name] -- ^ Constructor with field names
   deriving (Show, Eq, Ord, Typeable, Data
-#ifdef HAS_GENERIC
+#ifdef HAS_GENERICS
            ,Generic
 #endif
            )

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -1,4 +1,9 @@
-{-# Language CPP, DeriveGeneric, DeriveDataTypeable #-}
+{-# Language CPP, DeriveDataTypeable #-}
+
+#if MIN_VERSION_base(4,4,0)
+#define HAS_GENERIC
+{-# Language DeriveGeneric #-}
+#endif
 
 {-|
 Module      : Language.Haskell.TH.Datatype
@@ -113,7 +118,11 @@ data DatatypeInfo = DatatypeInfo
   , datatypeVariant :: DatatypeVariant   -- ^ Extra information
   , datatypeCons    :: [ConstructorInfo] -- ^ Normalize constructor information
   }
-  deriving (Show, Eq, Typeable, Data, Generic)
+  deriving (Show, Eq, Typeable, Data
+#ifdef HAS_GENERIC
+           ,Generic
+#endif
+           )
 
 -- | Possible variants of data type declarations.
 data DatatypeVariant
@@ -121,7 +130,11 @@ data DatatypeVariant
   | Newtype         -- ^ Type declared with @newtype@
   | DataInstance    -- ^ Type declared with @data instance@
   | NewtypeInstance -- ^ Type declared with @newtype instance@
-  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Typeable, Data
+#ifdef HAS_GENERIC
+           ,Generic
+#endif
+           )
 
 -- | Normalized information about constructors associated with newtypes and
 -- data types.
@@ -132,7 +145,11 @@ data ConstructorInfo = ConstructorInfo
   , constructorFields  :: [Type]             -- ^ Constructor fields
   , constructorVariant :: ConstructorVariant -- ^ Extra information
   }
-  deriving (Show, Eq, Typeable, Data, Generic)
+  deriving (Show, Eq, Typeable, Data
+#ifdef HAS_GENERIC
+           ,Generic
+#endif
+           )
 
 -- | Possible variants of data constructors.
 data ConstructorVariant
@@ -140,7 +157,11 @@ data ConstructorVariant
   | InfixConstructor         -- ^ Constructor without field names that is
                              --   declared infix
   | RecordConstructor [Name] -- ^ Constructor with field names
-  deriving (Show, Eq, Ord, Typeable, Data, Generic)
+  deriving (Show, Eq, Ord, Typeable, Data
+#ifdef HAS_GENERIC
+           ,Generic
+#endif
+           )
 
 
 -- | Construct a Type using the datatype's type constructor and type

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -28,7 +28,7 @@ library
   other-modules:       Language.Haskell.TH.Datatype.Internal
   build-depends:       base             >=4.3   && <5,
                        ghc-prim,
-                       template-haskell >=2.7   && <2.13,
+                       template-haskell >=2.4   && <2.13,
                        containers       >=0.4   && <0.6
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -26,7 +26,7 @@ source-repository head
 library
   exposed-modules:     Language.Haskell.TH.Datatype
   other-modules:       Language.Haskell.TH.Datatype.Internal
-  build-depends:       base             >=4.5   && <5,
+  build-depends:       base             >=4.3   && <5,
                        ghc-prim,
                        template-haskell >=2.7   && <2.13,
                        containers       >=0.4   && <0.6

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -28,7 +28,7 @@ library
   other-modules:       Language.Haskell.TH.Datatype.Internal
   build-depends:       base             >=4.3   && <5,
                        ghc-prim,
-                       template-haskell >=2.4   && <2.13,
+                       template-haskell >=2.5   && <2.13,
                        containers       >=0.4   && <0.6
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This most involves some compatibility hacks, including:

* There's no support in GHC 7.0 or 7.2 for reifying data family instances, so we just have to CPP that out.
* `Q` wasn't an `Applicative` instance (!?) back then, so we need to use `Monad` everywhere.