### PR TITLE
Use heterogeneous equality for reified GADT constraints

### DIFF
--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -1044,7 +1044,7 @@ classPred =
 #endif
 
 
--- | Match a 'Pred' representing an equality constraint (homogenoues or
+-- | Match a 'Pred' representing an equality constraint (homogeneous or
 -- heterogeneous). Returns arguments to the equality constraint if successful.
 asEqualPred :: Pred -> Maybe (Type,Type)
 #if MIN_VERSION_template_haskell(2,10,0)

--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -15,6 +15,9 @@ import Language.Haskell.TH.Syntax
 eqTypeName :: Name
 eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"
 
+heqTypeName :: Name
+heqTypeName = mkNameG_tc "ghc-prim" "GHC.Types" "~~"
+
 -- This is only needed for GHC 7.6-specific bug
 starKindName :: Name
 starKindName = mkNameG_tc "ghc-prim" "GHC.Prim" "*"


### PR DESCRIPTION
One approach to fix #6. This does have the downside of changing the output of `normalizeCon` conditionally based on the GHC version (although we do have `equalPred` anyways), so I wanted to get @glguy's opinion on this before merging.