### PR TITLE
Call reify less in GHC 7.6 and 7.8

### DIFF
--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -631,12 +631,16 @@ normalizeCon typename params variant = fmap (map giveTyVarBndrsStarKinds) . disp
           -- splices (see ##22).
           mightHaveBeenEtaReduced :: [Type] -> Bool
           mightHaveBeenEtaReduced [] = False
-          mightHaveBeenEtaReduced ts = isVarT (last ts)
+          mightHaveBeenEtaReduced ts =
+            case varTName (last ts) of
+              Nothing -> False
+              Just n  -> not (n `elem` freeVariables ts)
 
-          isVarT :: Type -> Bool
-          isVarT (SigT t _) = isVarT t
-          isVarT (VarT _)   = True
-          isVarT _          = False
+          -- If a Type is a VarT, find Just its Name. Otherwise, return Nothing.
+          varTName :: Type -> Maybe
+          varTName (SigT t _) = isVarT t
+          varTName (VarT n)   = Just n
+          varTName _          = Nothing
 
       in case variant of
            -- On GHC 7.6 and 7.8, there's quite a bit of post-processing that

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -86,6 +86,7 @@ data instance GadtFam c d where
   MkGadtFam5 :: (q ~ Char) => q -> GadtFam Bool Bool
 infixl 3 :&&:
 
+data family GadtLocalDec a
 #endif
 
 return [] -- segment type declarations above from refiy below
@@ -107,6 +108,7 @@ main =
      ghc78bugTest
      polyTest
      gadtFamTest
+     gadtDecTest
 #endif
      fixityLookupTest
 
@@ -476,6 +478,27 @@ gadtFamTest =
                    , constructorFields     = [qTy]
                    , constructorStrictness = [notStrictAnnot]
                    , constructorVariant    = NormalConstructor } ]
+           }
+   )
+
+gadtDecTest :: IO ()
+gadtDecTest =
+  $(do [dec] <- [d| data instance GadtLocalDec Int = GadtLocalDecInt { mochi :: Double } |]
+       info <- normalizeDec dec
+       validate info
+         DatatypeInfo
+           { datatypeName    = ''GadtLocalDec
+           , datatypeContext = []
+           , datatypeVars    = [ConT ''Int]
+           , datatypeVariant = DataInstance
+           , datatypeCons    =
+               [ ConstructorInfo
+                   { constructorName       = mkName "GadtLocalDecInt"
+                   , constructorVars       = []
+                   , constructorContext    = []
+                   , constructorFields     = [ConT ''Double]
+                   , constructorStrictness = [notStrictAnnot]
+                   , constructorVariant    = RecordConstructor [mkName "mochi"] }]
            }
    )
 #endif


### PR DESCRIPTION
This provides a sufficient hack to avoid the error encountered in https://travis-ci.org/ekmett/lens/jobs/241242901#L1124.

This is half of the code needed for #22. (There's still the remaining issue of guarding uses of `reify` with `recover`.)