### PR TITLE
Fix #36 by alpha-renaming bound GADT constructor variables

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for th-abstraction
 
+## next -- ????-??-??
+
+* Fix bug that caused GADT equality constraints to be incorrect in some cases.
+
 ## 0.2.3.0 -- 2017-06-26
 
 * Add `resolvePredSynonyms`


### PR DESCRIPTION
Implements the approach described in https://github.com/glguy/th-abstraction/issues/36#issuecomment-313896765.