### PR TITLE
Fix #46 by being more careful about when to add to a GADT context

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for th-abstraction
 
+## next -- ????-??-??
+* Fix bug in which data family instances with duplicate occurrences of type
+  variables in the left-hand side would have redundant equality constraints
+  in their contexts.
+
 ## 0.2.6.0 -- 2017-09-04
 * Fix bug in which `applySubstitution` and `freeVariables` would ignore
   type variables in the kinds of type variable binders.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -62,6 +62,7 @@ main =
      famLocalDecTest1
      famLocalDecTest2
      recordFamTest
+     t46Test
 #endif
      fixityLookupTest
 #if __GLASGOW_HASKELL__ >= 704
@@ -511,6 +512,16 @@ recordFamTest :: IO ()
 recordFamTest =
   $(do info <- reifyRecord 'famRec1
        validateCI info gadtRecFamCI)
+
+t46Test :: IO ()
+t46Test =
+  $(do info <- reifyDatatype 'MkT46
+       case info of
+         DatatypeInfo { datatypeCons = [ConstructorInfo { constructorContext = ctxt }]} ->
+           unless (null ctxt) (fail "regression test for ticket #46 failed")
+         _ -> fail "T46 should have exactly one constructor"
+       [| return () |])
+
 #endif
 
 fixityLookupTest :: IO ()

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -95,6 +95,9 @@ infixl 3 :&&:, :#%:
 
 data family FamLocalDec1 a
 data family FamLocalDec2 a b c
+
+data family   T46 a b c
+data instance T46 (f (p :: *)) (f p) q = MkT46 q
 #endif
 
 #if __GLASGOW_HASKELL__ >= 704


### PR DESCRIPTION
When merging GADT type variables in `mergeArguments`, we were failing to properly account for the possibility of duplicate type variables, which can happen with data family instances. This patch adds some special-casing to `mergeArguments`' `VarT` case to ensure that we catch this and do not add redundant constraints in the event that there are duplicate type variable names.