### PR TITLE
Fix #37 by closing over kinds

### DIFF
--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -117,7 +117,7 @@ module Language.Haskell.TH.Datatype
 
 import           Data.Data (Typeable, Data)
 import           Data.Foldable (foldMap, foldl')
-import           Data.List (nub, nubBy, find, union, (\\))
+import           Data.List (nub, find, union, (\\))
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe
@@ -1000,8 +1000,8 @@ closeOverKinds domainFVKinds rangeFVKinds = go
                  then (Map.empty, [])
                  else go (kindSubst, kindContext)
           finalSubst   = Map.unions [subst, kindSubst, restSubst]
-          finalContext = nubBy eqPred $ concat [context, kindContext, restContext]
-            -- Use `nubBy eqPred` here in an effort to minimize the number of
+          finalContext = nub $ concat [context, kindContext, restContext]
+            -- Use `nub` here in an effort to minimize the number of
             -- redundant equality constraints in the returned context.
       in (finalSubst, finalContext)
 
@@ -1492,17 +1492,6 @@ classPred =
 #else
   ClassP
 #endif
-
--- Attempts to be somewhat more intelligent than Pred's Eq instance in that
--- it recognizes the symmetry of equality. For example, eqPred would consider
--- the predicates (a ~ Int) and (Int ~ a) to be equal.
-eqPred :: Pred -> Pred -> Bool
-eqPred p1 p2
-  | Just (x1, y1) <- asEqualPred p1
-  , Just (x2, y2) <- asEqualPred p2
-  = (x1 == x2 && y1 == y2) || (x1 == y2 && x2 == y1)
-  | otherwise
-  = p1 == p2
 
 -- | Match a 'Pred' representing an equality constraint. Returns
 -- arguments to the equality constraint if successful.

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -117,7 +117,7 @@ module Language.Haskell.TH.Datatype
 
 import           Data.Data (Typeable, Data)
 import           Data.Foldable (foldMap, foldl')
-import           Data.List (nub, find, union, (\\))
+import           Data.List (nub, nubBy, find, union, (\\))
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe
@@ -909,7 +909,10 @@ normalizeGadtC typename params tyvars context names innerType
      case decomposeType innerType' of
        ConT innerTyCon :| ts | typename == innerTyCon ->
 
-         let (substName, context1) = mergeArguments params ts
+         let (substName, context1) =
+               closeOverKinds (kindsOfFVsOfTvbs renamedTyvars)
+                              (kindsOfFVsOfTypes params)
+                              (mergeArguments params ts)
              subst    = VarT <$> substName
              exTyvars = [ tv | tv <- renamedTyvars, Map.notMember (tvName tv) subst ]
 
@@ -923,6 +926,120 @@ normalizeGadtC typename params tyvars context names innerType
                      ]
 
        _ -> fail "normalizeGadtC: Expected type constructor application"
+
+{-
+Extend a type variable renaming subtitution and a list of equality
+predicates by looking into kind information as much as possible.
+
+Why is this necessary? Consider the following example:
+
+  data (a1 :: k1) :~: (b1 :: k1) where
+    Refl :: forall k2 (a2 :: k2). a2 :~: a2
+
+After an initial call to mergeArguments, we will have the following
+substitution and context:
+
+* Substitution: [a2 :-> a1]
+* Context: (a2 ~ b1)
+
+We shouldn't stop there, however! We determine the existentially quantified
+type variables of a constructor by filtering out those constructor-bound
+variables which do not appear in the substitution that mergeArguments
+returns. In this example, Refl's bound variables are k2 and a2. a2 appears
+in the returned substitution, but k2 does not, which means that we would
+mistakenly conclude that k2 is existential!
+
+Although we don't have the full power of kind inference to guide us here, we
+can at least do the next best thing. Generally, the datatype-bound type
+variables and the constructor type variable binders contain all of the kind
+information we need, so we proceed as follows:
+
+1. Construct a map from each constructor-bound variable to its kind. (Do the
+   same for each datatype-bound variable). These maps are the first and second
+   arguments to closeOverKinds, respectively.
+2. Call mergeArguments once on the GADT return type and datatype-bound types,
+   and pass that in as the third argument to closeOverKinds.
+3. For each name-name pair in the supplied substitution, check if the first and
+   second names map to kinds in the first and second kind maps in
+   closeOverKinds, respectively. If so, associate the first kind with the
+   second kind.
+4. For each kind association discovered in part (3), call mergeArguments
+   on the lists of kinds. This will yield a kind substitution and kind
+   equality context.
+5. If the kind substitution is non-empty, then go back to step (3) and repeat
+   the process on the new kind substitution and context.
+
+   Otherwise, if the kind substitution is empty, then we have reached a fixed-
+   point (i.e., we have closed over the kinds), so proceed.
+6. Union up all of the substitutions and contexts, and return those.
+
+This algorithm is not perfect, as it will only catch everything if all of
+the kinds are explicitly mentioned somewhere (and not left quantified
+implicitly). Thankfully, reifying data types via Template Haskell tends to
+yield a healthy amount of kind signatures, so this works quite well in
+practice.
+-}
+closeOverKinds :: Map Name Kind
+               -> Map Name Kind
+               -> (Map Name Name, Cxt)
+               -> (Map Name Name, Cxt)
+closeOverKinds domainFVKinds rangeFVKinds = go
+  where
+    go :: (Map Name Name, Cxt) -> (Map Name Name, Cxt)
+    go (subst, context) =
+      let substList = Map.toList subst
+          (kindsInner, kindsOuter) =
+            unzip $
+            mapMaybe (\(d, r) -> do d' <- Map.lookup d domainFVKinds
+                                    r' <- Map.lookup r rangeFVKinds
+                                    return (d', r'))
+                     substList
+          (kindSubst, kindContext) = mergeArgumentKinds kindsOuter kindsInner
+          (restSubst, restContext)
+            = if Map.null kindSubst -- Fixed-point calculation
+                 then (Map.empty, [])
+                 else go (kindSubst, kindContext)
+          finalSubst   = Map.unions [subst, kindSubst, restSubst]
+          finalContext = nubBy eqPred $ concat [context, kindContext, restContext]
+            -- Use `nubBy eqPred` here in an effort to minimize the number of
+            -- redundant equality constraints in the returned context.
+      in (finalSubst, finalContext)
+
+-- Look into a list of types and map each free variable name to its kind.
+kindsOfFVsOfTypes :: [Type] -> Map Name Kind
+kindsOfFVsOfTypes = foldMap go
+  where
+    go :: Type -> Map Name Kind
+    go (ForallT {}) = error "`forall` type used in data family pattern"
+    go (AppT t1 t2) = go t1 `Map.union` go t2
+    go (SigT t k) =
+      let kSigs =
+#if MIN_VERSION_template_haskell(2,8,0)
+                  go k
+#else
+                  Map.empty
+#endif
+      in case t of
+           VarT n -> Map.insert n k kSigs
+           _      -> go t `Map.union` kSigs
+    go _ = Map.empty
+
+-- Look into a list of type variable binder and map each free variable name
+-- to its kind (also map the names that KindedTVs bind to their respective
+-- kinds). This function considers the kind of a PlainTV to be *.
+kindsOfFVsOfTvbs :: [TyVarBndr] -> Map Name Kind
+kindsOfFVsOfTvbs = foldMap go
+  where
+    go :: TyVarBndr -> Map Name Kind
+    go (PlainTV n) = Map.singleton n starK
+    go (KindedTV n k) =
+      let kSigs =
+#if MIN_VERSION_template_haskell(2,8,0)
+                  kindsOfFVsOfTypes [k]
+#else
+                  Map.empty
+#endif
+      in Map.insert n k kSigs
 
 mergeArguments ::
   [Type] {- ^ outer parameters                    -} ->
@@ -953,6 +1070,19 @@ mergeArguments ns ts = foldr aux (Map.empty, []) (zip ns ts)
     aux (x, SigT y _) sc = aux (x,y) sc
 
     aux _ sc = sc
+
+-- | A specialization of 'mergeArguments' to 'Kind'.
+-- Needed only for backwards compatibility with older versions of
+-- @template-haskell@.
+mergeArgumentKinds ::
+  [Kind] ->
+  [Kind] ->
+  (Map Name Name, Cxt)
+#if MIN_VERSION_template_haskell(2,8,0)
+mergeArgumentKinds = mergeArguments
+#else
+mergeArgumentKinds _ _ = (Map.empty, [])
+#endif
 
 -- | Expand all of the type synonyms in a type.
 resolveTypeSynonyms :: Type -> Q Type
@@ -1363,6 +1493,16 @@ classPred =
   ClassP
 #endif
 
+-- Attempts to be somewhat more intelligent than Pred's Eq instance in that
+-- it recognizes the symmetry of equality. For example, eqPred would consider
+-- the predicates (a ~ Int) and (Int ~ a) to be equal.
+eqPred :: Pred -> Pred -> Bool
+eqPred p1 p2
+  | Just (x1, y1) <- asEqualPred p1
+  , Just (x2, y2) <- asEqualPred p2
+  = (x1 == x2 && y1 == y2) || (x1 == y2 && x2 == y1)
+  | otherwise
+  = p1 == p2
 
 -- | Match a 'Pred' representing an equality constraint. Returns
 -- arguments to the equality constraint if successful.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -590,16 +590,7 @@ importedEqualityTest =
            , datatypeCons    =
                [ ConstructorInfo
                    { constructorName       = 'Refl
-                   , constructorVars       =
-# if MIN_VERSION_template_haskell(2,11,0)
-                                             [KindedTV k starK]
-# else
-                                             []
-# endif
-                     -- Unfortunately, due to #37, th-abstraction incorrectly
-                     -- concludes that k is existentially quantified on GHC
-                     -- 8.0 and later.
-
+                   , constructorVars       = []
                    , constructorContext    = [equalPred a b]
                    , constructorFields     = []
                    , constructorStrictness = []

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -622,19 +622,53 @@ kindSubstTest =
 #if __GLASGOW_HASKELL__ >= 800
 t37Test :: IO ()
 t37Test =
-  $(do info <- reifyDatatype ''T37
+  $(do infoA <- reifyDatatype ''T37a
        let [k,a] = map (VarT . mkName) ["k","a"]
-       validateDI info
+       validateDI infoA
          DatatypeInfo
            { datatypeContext = []
-           , datatypeName    = ''T37
+           , datatypeName    = ''T37a
            , datatypeVars    = [SigT k starK, SigT a k]
            , datatypeVariant = Datatype
            , datatypeCons    =
                [ ConstructorInfo
-                   { constructorName       = 'MkT37
+                   { constructorName       = 'MkT37a
                    , constructorVars       = []
                    , constructorContext    = [equalPred k (ConT ''Bool)]
+                   , constructorFields     = []
+                   , constructorStrictness = []
+                   , constructorVariant    = NormalConstructor } ]
+           }
+
+       infoB <- reifyDatatype ''T37b
+       validateDI infoB
+         DatatypeInfo
+           { datatypeContext = []
+           , datatypeName    = ''T37b
+           , datatypeVars    = [SigT a k]
+           , datatypeVariant = Datatype
+           , datatypeCons    =
+               [ ConstructorInfo
+                   { constructorName       = 'MkT37b
+                   , constructorVars       = []
+                   , constructorContext    = [equalPred k (ConT ''Bool)]
+                   , constructorFields     = []
+                   , constructorStrictness = []
+                   , constructorVariant    = NormalConstructor } ]
+           }
+
+       infoC <- reifyDatatype ''T37c
+       validateDI infoC
+         DatatypeInfo
+           { datatypeContext = []
+           , datatypeName    = ''T37c
+           , datatypeVars    = [SigT a k]
+           , datatypeVariant = Datatype
+           , datatypeCons    =
+               [ ConstructorInfo
+                   { constructorName       = 'MkT37c
+                   , constructorVars       = []
+                   , constructorContext    = [equalPred a (ConT ''Bool)]
                    , constructorFields     = []
                    , constructorStrictness = []
                    , constructorVariant    = NormalConstructor } ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -77,6 +77,7 @@ main =
      kindSubstTest
 #endif
 #if __GLASGOW_HASKELL__ >= 800
+     t37Test
      polyKindedExTyvarTest
 #endif
      regressionTest44
@@ -619,6 +620,27 @@ kindSubstTest =
 #endif
 
 #if __GLASGOW_HASKELL__ >= 800
+t37Test :: IO ()
+t37Test =
+  $(do info <- reifyDatatype ''T37
+       let [k,a] = map (VarT . mkName) ["k","a"]
+       validateDI info
+         DatatypeInfo
+           { datatypeContext = []
+           , datatypeName    = ''T37
+           , datatypeVars    = [SigT k starK, SigT a k]
+           , datatypeVariant = Datatype
+           , datatypeCons    =
+               [ ConstructorInfo
+                   { constructorName       = 'MkT37
+                   , constructorVars       = []
+                   , constructorContext    = [equalPred k (ConT ''Bool)]
+                   , constructorFields     = []
+                   , constructorStrictness = []
+                   , constructorVariant    = NormalConstructor } ]
+           }
+   )
+
 polyKindedExTyvarTest :: IO ()
 polyKindedExTyvarTest =
   $(do info <- reifyDatatype ''T48

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -121,8 +121,14 @@ data PredSynT =
 #endif
 
 #if __GLASGOW_HASKELL__ >= 800
-data T37 (k :: Type) :: k -> Type where
-  MkT37 :: T37 Bool a
+data T37a (k :: Type) :: k -> Type where
+  MkT37a :: T37a Bool a
+
+data T37b (a :: k) where
+  MkT37b :: forall (a :: Bool). T37b a
+
+data T37c (a :: k) where
+  MkT37c :: T37c Bool
 
 data Prox (a :: k) = Prox
 

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -121,6 +121,9 @@ data PredSynT =
 #endif
 
 #if __GLASGOW_HASKELL__ >= 800
+data T37 (k :: Type) :: k -> Type where
+  MkT37 :: T37 Bool a
+
 data Prox (a :: k) = Prox
 
 data T48 :: Type -> Type where


### PR DESCRIPTION
`th-abstraction` was incorrectly concluding that kind variables were existential when in reality, they were actually universal. At first, I thought we'd need the full power of GHC's kind inference in order to solve this problem, but luckily, it turns out a much simpler approach will do.

I explain the full algorithm in the documentation for the `closeOverKinds` function. In a nutshell, it:

1. Takes the substitution that `mergeArguments` produces, and pairs up the kinds of the domain and range of the substitution
2. Merges those kinds
3. If there's any kind variables in the resulting kind substitution, repeat. Otherwise, we're done, so union up the new substitutions (and equality constraints, if any were produced) and return.

It's not perfect, but it fixes #37 quite nicely. With this patch, `th-abstraction` is now quite robust with respect to poly-kinded GADTs, which has long been a goal of mine.