### PR TITLE
Fix #59 by introducing and using freeVariablesWellScoped

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,8 +5,8 @@
   type variables (e.g., `Proxy (a :: k)` would have erroneously been quantified
   as `forall a k. Proxy (a :: k)`).
 * Fix a bug in which `asEqualPred` would return incorrect results with GHC 8.7.
-* Add a `toposortTyVarsOf` function which finds the free variables of a list of
-  types and sorts them according to dependency order.
+* Add a `freeVariablesWellScoped` function which computes the free variables of
+  a list of types and sorts them according to dependency order.
 
 ## 0.2.8.0 -- 2018-06-29
 * GADT reification is now much more robust with respect to `PolyKinds`:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,12 @@
 # Revision history for th-abstraction
 
 ## next -- ????-??-??
+* Fix a bug in which `quantifyType` would not respect the dependency order of
+  type variables (e.g., `Proxy (a :: k)` would have erroneously been quantified
+  as `forall a k. Proxy (a :: k)`).
 * Fix a bug in which `asEqualPred` would return incorrect results with GHC 8.7.
+* Add a `toposortTyVarsOf` function which finds the free variables of a list of
+  types and sorts them according to dependency order.
 
 ## 0.2.8.0 -- 2018-06-29
 * GADT reification is now much more robust with respect to `PolyKinds`:


### PR DESCRIPTION
`toposortTyVarsOf`, which originally debuted in `th-desugar`, is quite useful for recovering the dependency order of free type variable. This introduces a version of the function tailored to `th-abstraction`'s needs and uses it to more correctly implement `quantifyType`.