### PR TITLE
Fix #61 by making resolveTypeSynonyms more robust

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,12 +1,17 @@
 # Revision history for th-abstraction
 
 ## next -- ????-??-??
+* Fix a bug in which `resolveTypeSynonyms` would not look into `ForallT`s,
+  `SigT`s, `InfixT`s, or `ParensT`s.
 * Fix a bug in which `quantifyType` would not respect the dependency order of
   type variables (e.g., `Proxy (a :: k)` would have erroneously been quantified
   as `forall a k. Proxy (a :: k)`).
 * Fix a bug in which `asEqualPred` would return incorrect results with GHC 8.7.
 * Add a `freeVariablesWellScoped` function which computes the free variables of
   a list of types and sorts them according to dependency order.
+* Add a `resolveKindSynonyms` function which expands all type synonyms in a
+  `Kind`. This is mostly useful for supporting old GHCs where `Type` and `Kind`
+  were not the same.
 
 ## 0.2.8.0 -- 2018-06-29
 * GADT reification is now much more robust with respect to `PolyKinds`:

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -71,6 +71,8 @@ data StrictDemo = StrictDemo Int !Int {-# UNPACK #-} !Int
 -- Data families
 data family T43Fam
 
+type Id (a :: *) = a
+
 #if MIN_VERSION_template_haskell(2,7,0)
 data family DF (a :: *)
 data instance DF (Maybe a) = DFMaybe Int [a]


### PR DESCRIPTION
There are several `Type` forms that `resolveTypeSynonyms` simply doesn't work for, as documented in #61. This patch fixes this by making `resolveTypeSynonyms` sufficiently smarter:

* We now look through `InfixT`, `UInfixT`, `ParensT`, `SigT`, and `ParensT` when expanding type synonyms.
* Along the way, I found it useful to define `resolveKindSynonyms`, a counterpart to `resolveTypeSynonyms` for `Kind`s. Since it fits nicely with the already-exported `resolveTypeSynonym` and `resolvePredSynonym` functions, I decided to export `resolveKindSynonyms` as well.