### PR TITLE
Fix #63 by collapsing consecutive foralls in quantifyType

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for th-abstraction
 
+## next -- ????-??-??
+* Optimization: `quantifyType` now collapses consecutive `forall`s. For
+  instance, calling `quantifyType` on `forall b. a -> b -> T a` now produces
+  `forall a b. a -> b -> T a` instead of `forall a. forall b. a -> b -> T a`.
+
 ## 0.2.9.0 -- 2018-12-20
 * Fix a bug in which `resolveTypeSynonyms` would not look into `ForallT`s,
   `SigT`s, `InfixT`s, or `ParensT`s.

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -1342,8 +1342,12 @@ conHasRecord recName info =
 -- contrast with being dependent upon the Ord instance for 'Name')
 quantifyType :: Type -> Type
 quantifyType t
-  | null tvbs = t
-  | otherwise = ForallT tvbs [] t
+  | null tvbs
+  = t
+  | ForallT tvbs' ctxt' t' <- t -- Collapse two consecutive foralls (#63)
+  = ForallT (tvbs ++ tvbs') ctxt' t'
+  | otherwise
+  = ForallT tvbs [] t
   where
     tvbs = freeVariablesWellScoped [t]
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -86,6 +86,7 @@ main =
      polyKindedExTyvarTest
 #endif
      regressionTest44
+     t63Test
 
 adt1Test :: IO ()
 adt1Test =
@@ -813,4 +814,21 @@ regressionTest44 =
   $(do intToInt <- [t| Int -> Int |]
        unified  <- unifyTypes [intToInt, intToInt]
        unless (Map.null unified) (fail "regression test for ticket #44 failed")
+       [| return () |])
+
+t63Test :: IO ()
+t63Test =
+  $(do a <- newName "a"
+       b <- newName "b"
+       t <- newName "T"
+       let tauType = ArrowT `AppT` VarT a `AppT` (ArrowT `AppT` VarT b
+                       `AppT` (ConT t `AppT` VarT a))
+           sigmaType = ForallT [PlainTV b] [] tauType
+           expected = ForallT [PlainTV a, PlainTV b] [] tauType
+           actual   = quantifyType sigmaType
+       unless (expected == actual) $
+         fail $ "quantifyType does not collapse consecutive foralls: "
+             ++ unlines [ "Expected: " ++ pprint expected
+                        , "Actual:   " ++ pprint actual
+                        ]
        [| return () |])


### PR DESCRIPTION
A simple but useful optimization. Fixes #63. 