### PR TITLE
Adapt to "More explicit foralls" and "Visible kind application"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 # Revision history for th-abstraction
 
+## next -- ????-??-??
+* Breaking change: the `datatypeVars` field of `DatatypeInfo` is now of type
+  `[TyVarBndr]` instead of `[Type]`, as it now refers to all of the bound type
+  variables in the data type. The old `datatypeVars` field has been renamed to
+  `datatypeInstTypes` to better reflect its purpose.
+
+  In addition, the type of `normalizeCon` now has an additional `[TyVarBndr]`
+  argument, since `DatatypeInfo` now requires it.
+* Support `template-haskell-2.15`.
+
 ## 0.2.10.0 -- 2018-12-20
 * Optimization: `quantifyType` now collapses consecutive `forall`s. For
   instance, calling `quantifyType` on `forall b. a -> b -> T a` now produces

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -20,11 +20,12 @@ Sample output for @'reifyDatatype' ''Maybe@
 
 @
 'DatatypeInfo'
- { 'datatypeContext' = []
- , 'datatypeName'    = GHC.Base.Maybe
- , 'datatypeVars'    = [ 'SigT' ('VarT' a_3530822107858468866) 'StarT' ]
- , 'datatypeVariant' = 'Datatype'
- , 'datatypeCons'    =
+ { 'datatypeContext'   = []
+ , 'datatypeName'      = GHC.Base.Maybe
+ , 'datatypeVars'      = [ 'KindedTV' a_3530822107858468866 'StarT' ]
+ , 'datatypeInstTypes' = [ 'SigT' ('VarT' a_3530822107858468866) 'StarT' ]
+ , 'datatypeVariant'   = 'Datatype'
+ , 'datatypeCons'      =
      [ 'ConstructorInfo'
          { 'constructorName'       = GHC.Base.Nothing
          , 'constructorVars'       = []
@@ -144,16 +145,51 @@ import           Data.Monoid (Monoid(..))
 
 -- | Normalized information about newtypes and data types.
 --
--- 'datatypeVars' types will have an outermost 'SigT' to indicate the
--- parameter's kind. These types will be simple variables for /ADT/s
--- declared with @data@ and @newtype@, but can be more complex for
--- types declared with @data instance@ and @newtype instance@.
+-- 'DatatypeInfo' contains two fields, 'datatypeVars' and 'datatypeInstTypes',
+-- which encode information about the argument types. The simplest explanation
+-- is that 'datatypeVars' contains all the type /variables/ bound by the data
+-- type constructor, while 'datatypeInstTypes' contains the type /arguments/
+-- to the data type constructor. To be more precise:
+--
+-- * For ADTs declared with @data@ and @newtype@, it will likely be the case
+--   that 'datatypeVars' and 'datatypeInstTypes' coincide. For instance, given
+--   @newtype Id a = MkId a@, in the 'DatatypeInfo' for @Id@ we would
+--   have @'datatypeVars' = ['KindedTV' a 'StarT']@ and
+--   @'datatypeInstVars' = ['SigT' ('VarT' a) 'StarT']@.
+--
+--   ADTs that leverage @PolyKinds@ may have more 'datatypeVars' than
+--   'datatypeInstTypes'. For instance, given @data Proxy (a :: k) = MkProxy@,
+--   in the 'DatatypeInfo' for @Proxy@ we would have
+--   @'datatypeVars' = ['KindedTV' k 'StarT', 'KindedTV' a ('VarT' k)]@ (since
+--   there are two variables, @k@ and @a@), whereas
+--   @'datatypeInstTypes' = ['SigT' ('VarT' a) ('VarT' k)]@, since there is
+--   only one explicit type argument to @Proxy@.
+--
+-- * For @data instance@s and @newtype instance@s of data families,
+--   'datatypeVars' and 'datatypeInstTypes' can be quite different. Here is
+--   an example to illustrate the difference:
+--
+--   @
+--   data family F a b
+--   data instance F (Maybe c) (f x) = MkF c (f x)
+--   @
+--
+--   Then in the 'DatatypeInfo' for @F@'s data instance, we would have:
+--
+--   @
+--   'datatypeVars'      = [ 'KindedTV' c 'StarT'
+--                         , 'KindedTV' f 'StarT'
+--                         , 'KindedTV' x 'StarT' ]
+--   'datatypeInstTypes' = [ 'AppT' ('ConT' ''Maybe) ('VarT' c)
+--                         , 'AppT' ('VarT' f) ('VarT' x) ]
+--   @
 data DatatypeInfo = DatatypeInfo
-  { datatypeContext :: Cxt               -- ^ Data type context (deprecated)
-  , datatypeName    :: Name              -- ^ Type constructor
-  , datatypeVars    :: [Type]            -- ^ Type parameters
-  , datatypeVariant :: DatatypeVariant   -- ^ Extra information
-  , datatypeCons    :: [ConstructorInfo] -- ^ Normalize constructor information
+  { datatypeContext   :: Cxt               -- ^ Data type context (deprecated)
+  , datatypeName      :: Name              -- ^ Type constructor
+  , datatypeVars      :: [TyVarBndr]       -- ^ Type parameters
+  , datatypeInstTypes :: [Type]            -- ^ Argument types
+  , datatypeVariant   :: DatatypeVariant   -- ^ Extra information
+  , datatypeCons      :: [ConstructorInfo] -- ^ Normalize constructor information
   }
   deriving (Show, Eq, Typeable, Data
 #ifdef HAS_GENERICS
@@ -269,7 +305,7 @@ datatypeType :: DatatypeInfo -> Type
 datatypeType di
   = foldl AppT (ConT (datatypeName di))
   $ map stripSigT
-  $ datatypeVars di
+  $ datatypeInstTypes di
 
 
 -- | Compute a normalized view of the metadata about a data type or newtype
@@ -524,7 +560,21 @@ repairDataFam
     DataInstD cx n (repairVarKindsWith' dvars ts) cons deriv
 #else
 repairDataFam famD instD
-# if MIN_VERSION_template_haskell(2,11,0)
+# if MIN_VERSION_template_haskell(2,15,0)
+      | DataFamilyD _ dvars _ <- famD
+      , NewtypeInstD cx mbInstVars nts k c deriv <- instD
+      , con :| ts <- decomposeType nts
+      = NewtypeInstD cx mbInstVars
+          (foldl' AppT con (repairVarKindsWith (fromMaybe dvars mbInstVars) ts))
+          k c deriv
+
+      | DataFamilyD _ dvars _ <- famD
+      , DataInstD cx mbInstVars nts k c deriv <- instD
+      , con :| ts <- decomposeType nts
+      = DataInstD cx mbInstVars
+          (foldl' AppT con (repairVarKindsWith (fromMaybe dvars mbInstVars) ts))
+          k c deriv
+# elif MIN_VERSION_template_haskell(2,11,0)
       | DataFamilyD _ dvars _ <- famD
       , NewtypeInstD cx n ts k c deriv <- instD
       = NewtypeInstD cx n (repairVarKindsWith dvars ts) k c deriv
@@ -577,37 +627,58 @@ normalizeDecFor isReified dec =
   case dec of
 #if MIN_VERSION_template_haskell(2,12,0)
     NewtypeD context name tyvars _kind con _derives ->
-      giveTypesStarKinds <$> normalizeDec' isReified context name (bndrParams tyvars) [con] Newtype
+      let params = bndrParams tyvars in
+      giveDIVarsStarKinds <$> normalizeDec' isReified context name (freeVariablesWellScoped params) params [con] Newtype
     DataD context name tyvars _kind cons _derives ->
-      giveTypesStarKinds <$> normalizeDec' isReified context name (bndrParams tyvars) cons Datatype
-    NewtypeInstD context name params _kind con _derives ->
-      repair13618' . giveTypesStarKinds =<<
-      normalizeDec' isReified context name params [con] NewtypeInstance
-    DataInstD context name params _kind cons _derives ->
-      repair13618' . giveTypesStarKinds =<<
-      normalizeDec' isReified context name params cons DataInstance
+      let params = bndrParams tyvars in
+      giveDIVarsStarKinds <$> normalizeDec' isReified context name (freeVariablesWellScoped params) params cons Datatype
+# if MIN_VERSION_template_haskell(2,15,0)
+    NewtypeInstD context mbTyvars nameInstTys _kind con _derives ->
+      case decomposeType nameInstTys of
+        ConT name :| instTys ->
+          repair13618' . giveDIVarsStarKinds =<<
+          normalizeDec' isReified context name (fromMaybe (freeVariablesWellScoped instTys) mbTyvars) instTys [con] NewtypeInstance
+        _ -> fail $ "Unexpected newtype instance head: " ++ pprint nameInstTys
+    DataInstD context mbTyvars nameInstTys _kind cons _derives ->
+      case decomposeType nameInstTys of
+        ConT name :| instTys ->
+          repair13618' . giveDIVarsStarKinds =<<
+          normalizeDec' isReified context name (fromMaybe (freeVariablesWellScoped instTys) mbTyvars) instTys cons DataInstance
+        _ -> fail $ "Unexpected data instance head: " ++ pprint nameInstTys
+# else
+    NewtypeInstD context name instTys _kind con _derives ->
+      repair13618' . giveDIVarsStarKinds =<<
+      normalizeDec' isReified context name (freeVariablesWellScoped instTys) instTys [con] NewtypeInstance
+    DataInstD context name instTys _kind cons _derives ->
+      repair13618' . giveDIVarsStarKinds =<<
+      normalizeDec' isReified context name (freeVariablesWellScoped instTys) instTys cons DataInstance
+# endif
 #elif MIN_VERSION_template_haskell(2,11,0)
     NewtypeD context name tyvars _kind con _derives ->
-      giveTypesStarKinds <$> normalizeDec' isReified context name (bndrParams tyvars) [con] Newtype
+      let params = bndrParams tyvars in
+      giveDIVarsStarKinds <$> normalizeDec' isReified context name (freeVariablesWellScoped params) params [con] Newtype
     DataD context name tyvars _kind cons _derives ->
-      giveTypesStarKinds <$> normalizeDec' isReified context name (bndrParams tyvars) cons Datatype
-    NewtypeInstD context name params _kind con _derives ->
-      repair13618' . giveTypesStarKinds =<<
-      normalizeDec' isReified context name params [con] NewtypeInstance
-    DataInstD context name params _kind cons _derives ->
-      repair13618' . giveTypesStarKinds =<<
-      normalizeDec' isReified context name params cons DataInstance
+      let params = bndrParams tyvars in
+      giveDIVarsStarKinds <$> normalizeDec' isReified context name (freeVariablesWellScoped params) params cons Datatype
+    NewtypeInstD context name instTys _kind con _derives ->
+      repair13618' . giveDIVarsStarKinds =<<
+      normalizeDec' isReified context name (freeVariablesWellScoped instTys) instTys [con] NewtypeInstance
+    DataInstD context name instTys _kind cons _derives ->
+      repair13618' . giveDIVarsStarKinds =<<
+      normalizeDec' isReified context name (freeVariablesWellScoped instTys) instTys cons DataInstance
 #else
     NewtypeD context name tyvars con _derives ->
-      giveTypesStarKinds <$> normalizeDec' isReified context name (bndrParams tyvars) [con] Newtype
+      let params = bndrParams tyvars in
+      giveDIVarsStarKinds <$> normalizeDec' isReified context name (freeVariablesWellScoped params) params [con] Newtype
     DataD context name tyvars cons _derives ->
-      giveTypesStarKinds <$> normalizeDec' isReified context name (bndrParams tyvars) cons Datatype
-    NewtypeInstD context name params con _derives ->
-      repair13618' . giveTypesStarKinds =<<
-      normalizeDec' isReified context name params [con] NewtypeInstance
-    DataInstD context name params cons _derives ->
-      repair13618' . giveTypesStarKinds =<<
-      normalizeDec' isReified context name params cons DataInstance
+      let params = bndrParams tyvars in
+      giveDIVarsStarKinds <$> normalizeDec' isReified context name (freeVariablesWellScoped params) params cons Datatype
+    NewtypeInstD context name instTys con _derives ->
+      repair13618' . giveDIVarsStarKinds =<<
+      normalizeDec' isReified context name (freeVariablesWellScoped instTys) instTys [con] NewtypeInstance
+    DataInstD context name instTys cons _derives ->
+      repair13618' . giveDIVarsStarKinds =<<
+      normalizeDec' isReified context name (freeVariablesWellScoped instTys) instTys cons DataInstance
 #endif
     _ -> fail "normalizeDecFor: DataD or NewtypeD required"
   where
@@ -635,18 +706,20 @@ normalizeDec' ::
   IsReifiedDec    {- ^ Is this a reified 'Dec'? -} ->
   Cxt             {- ^ Datatype context         -} ->
   Name            {- ^ Type constructor         -} ->
-  [Type]          {- ^ Type parameters          -} ->
+  [TyVarBndr]     {- ^ Type parameters          -} ->
+  [Type]          {- ^ Argument types           -} ->
   [Con]           {- ^ Constructors             -} ->
   DatatypeVariant {- ^ Extra information        -} ->
   Q DatatypeInfo
-normalizeDec' reifiedDec context name params cons variant =
-  do cons' <- concat <$> mapM (normalizeConFor reifiedDec name params variant) cons
+normalizeDec' reifiedDec context name params instTys cons variant =
+  do cons' <- concat <$> mapM (normalizeConFor reifiedDec name params instTys variant) cons
      return DatatypeInfo
-       { datatypeContext = context
-       , datatypeName    = name
-       , datatypeVars    = params
-       , datatypeCons    = cons'
-       , datatypeVariant = variant
+       { datatypeContext   = context
+       , datatypeName      = name
+       , datatypeVars      = params
+       , datatypeInstTypes = instTys
+       , datatypeCons      = cons'
+       , datatypeVariant   = variant
        }
 
 -- | Normalize a 'Con' into a 'ConstructorInfo'. This requires knowledge of
@@ -655,7 +728,8 @@ normalizeDec' reifiedDec context name params cons variant =
 -- 'Dec'.
 normalizeCon ::
   Name            {- ^ Type constructor  -} ->
-  [Type]          {- ^ Type parameters   -} ->
+  [TyVarBndr]     {- ^ Type parameters   -} ->
+  [Type]          {- ^ Argument types    -} ->
   DatatypeVariant {- ^ Extra information -} ->
   Con             {- ^ Constructor       -} ->
   Q [ConstructorInfo]
@@ -664,11 +738,13 @@ normalizeCon = normalizeConFor isn'tReified
 normalizeConFor ::
   IsReifiedDec    {- ^ Is this a reified 'Dec'? -} ->
   Name            {- ^ Type constructor         -} ->
-  [Type]          {- ^ Type parameters          -} ->
+  [TyVarBndr]     {- ^ Type parameters          -} ->
+  [Type]          {- ^ Argument types           -} ->
   DatatypeVariant {- ^ Extra information        -} ->
   Con             {- ^ Constructor              -} ->
   Q [ConstructorInfo]
-normalizeConFor reifiedDec typename params variant = fmap (map giveTyVarBndrsStarKinds) . dispatch
+normalizeConFor reifiedDec typename params instTys variant =
+  fmap (map giveCIVarsStarKinds) . dispatch
   where
     -- A GADT constructor is declared infix when:
     --
@@ -755,7 +831,7 @@ normalizeConFor reifiedDec typename params variant = fmap (map giveTyVarBndrsSta
                     gadtCase ns innerType (takeFieldTypes xs) stricts
                              (const $ return $ RecordConstructor fns)
                 where
-                  gadtCase = normalizeGadtC typename params tyvars context
+                  gadtCase = normalizeGadtC typename params instTys tyvars context
 #endif
 #if MIN_VERSION_template_haskell(2,8,0) && (!MIN_VERSION_template_haskell(2,10,0))
           dataFamCompatCase :: Con -> Q [ConstructorInfo]
@@ -795,7 +871,7 @@ normalizeConFor reifiedDec typename params variant = fmap (map giveTyVarBndrsSta
                 -- substituting those types with the variables we put in
                 -- place of the eta-reduced variables (in normalizeDec)
                 -- much easier.
-                normalizeGadtC typename params tyvars context [n]
+                normalizeGadtC typename params instTys tyvars context [n]
                                returnTy' argTys stricts (const $ return variant)
               _ -> fail $ unlines
                      [ "normalizeCon: Cannot reify constructor " ++ nameBase n
@@ -840,10 +916,10 @@ normalizeConFor reifiedDec typename params variant = fmap (map giveTyVarBndrsSta
            -- needs to be performed to work around an old bug that eta-reduces the
            -- type patterns of data families (but only for reified data family instances).
            DataInstance
-             | reifiedDec, mightHaveBeenEtaReduced params
+             | reifiedDec, mightHaveBeenEtaReduced instTys
              -> dataFamCompatCase
            NewtypeInstance
-             | reifiedDec, mightHaveBeenEtaReduced params
+             | reifiedDec, mightHaveBeenEtaReduced instTys
              -> dataFamCompatCase
            _ -> defaultCase
 #else
@@ -876,7 +952,8 @@ normalizeStrictness Unpacked  = unpackedAnnot
 
 normalizeGadtC ::
   Name              {- ^ Type constructor             -} ->
-  [Type]            {- ^ Type parameters              -} ->
+  [TyVarBndr]       {- ^ Type parameters              -} ->
+  [Type]            {- ^ Argument types               -} ->
   [TyVarBndr]       {- ^ Constructor parameters       -} ->
   Cxt               {- ^ Constructor context          -} ->
   [Name]            {- ^ Constructor names            -} ->
@@ -887,7 +964,7 @@ normalizeGadtC ::
                     {- ^ Determine a constructor variant
                          from its 'Name' -}              ->
   Q [ConstructorInfo]
-normalizeGadtC typename params tyvars context names innerType
+normalizeGadtC typename params instTys tyvars context names innerType
                fields stricts getVariant =
   do -- Due to GHC Trac #13885, it's possible that the type variables bound by
      -- a GADT constructor will shadow those that are bound by the data type.
@@ -915,8 +992,8 @@ normalizeGadtC typename params tyvars context names innerType
 
          let (substName, context1) =
                closeOverKinds (kindsOfFVsOfTvbs renamedTyvars)
-                              (kindsOfFVsOfTypes params)
-                              (mergeArguments params ts)
+                              (kindsOfFVsOfTvbs params)
+                              (mergeArguments instTys ts)
              subst    = VarT <$> substName
              exTyvars = [ tv | tv <- renamedTyvars, Map.notMember (tvName tv) subst ]
 
@@ -1093,10 +1170,10 @@ mergeArgumentKinds _ _ = (Map.empty, [])
 -- Note that this function will drop parentheses as a side effect.
 resolveTypeSynonyms :: Type -> Q Type
 resolveTypeSynonyms t =
-  let f :| xs = decomposeType t
+  let (f, xs) = decomposeTypeArgs t
 
       notTypeSynCase :: Type -> Q Type
-      notTypeSynCase ty = foldl AppT ty <$> mapM resolveTypeSynonyms xs
+      notTypeSynCase ty = foldl appTypeArg ty <$> mapM resolveTypeArgSynonyms xs
 
       expandCon :: Name -- The Name to check whether it is a type synonym or not
                 -> Type -- The argument type to fall back on if the supplied
@@ -1106,7 +1183,7 @@ resolveTypeSynonyms t =
         mbInfo <- reifyMaybe n
         case mbInfo of
           Just (TyConI (TySynD _ synvars def))
-            -> resolveTypeSynonyms $ expandSynonymRHS synvars xs def
+            -> resolveTypeSynonyms $ expandSynonymRHS synvars (filterTANormals xs) def
           _ -> notTypeSynCase ty
 
   in case f of
@@ -1129,7 +1206,16 @@ resolveTypeSynonyms t =
          t2' <- resolveTypeSynonyms t2
          expandCon n (UInfixT t1' n t2')
 #endif
+#if MIN_VERSION_template_haskell(2,15,0)
+       ImplicitParamT n t -> do
+         ImplicitParamT n `fmap` resolveTypeSynonyms t
+#endif
        _ -> notTypeSynCase f
+
+-- | Expand all of the type synonyms in a 'TypeArg'.
+resolveTypeArgSynonyms :: TypeArg -> Q TypeArg
+resolveTypeArgSynonyms (TANormal t) = TANormal <$> resolveTypeSynonyms t
+resolveTypeArgSynonyms (TyArg k)    = TyArg    <$> resolveKindSynonyms k
 
 -- | Expand all of the type synonyms in a 'Kind'.
 resolveKindSynonyms :: Kind -> Q Kind
@@ -1192,20 +1278,56 @@ typeToPred t =
 #endif
 
 -- | Decompose a type into a list of it's outermost applications. This process
--- forgets about infix application and explicit parentheses.
+-- forgets about infix application, explicit parentheses, and visible kind
+-- applications.
 --
 -- This operation should be used after all 'UInfixT' cases have been resolved
 -- by 'resolveFixities' if the argument is being user generated.
 --
 -- > t ~= foldl1 AppT (decomposeType t)
 decomposeType :: Type -> NonEmpty Type
-decomposeType = go []
+decomposeType t =
+  case decomposeTypeArgs t of
+    (f, x) -> f :| filterTANormals x
+
+-- | A variant of 'decomposeType' that preserves information about visible kind
+-- applications by returning a 'NonEmpty' list of 'TypeArg's.
+decomposeTypeArgs :: Type -> (Type, [TypeArg])
+decomposeTypeArgs = go []
   where
-    go args (AppT f x)  = go (x:args) f
+    go :: [TypeArg] -> Type -> (Type, [TypeArg])
+    go args (AppT f x)     = go (TANormal x:args) f
 #if MIN_VERSION_template_haskell(2,11,0)
-    go args (ParensT t) = go args t
+    go args (ParensT t)    = go args t
 #endif
-    go args t           = t :| args
+#if MIN_VERSION_template_haskell(2,15,0)
+    go args (AppKindT f x) = go (TyArg x:args) f
+#endif
+    go args t              = (t, args)
+
+-- | An argument to a type, either a normal type ('TANormal') or a visible
+-- kind application ('TyArg').
+data TypeArg
+  = TANormal Type
+  | TyArg Kind
+
+-- | Apply a 'Type' to a 'TypeArg'.
+appTypeArg :: Type -> TypeArg -> Type
+appTypeArg f (TANormal x) = f `AppT` x
+appTypeArg f (TyArg k) =
+#if MIN_VERSION_template_haskell(2,15,0)
+  f `AppKindT` k
+#else
+  error "Visible kind applications only supported with template-haskell-2.15+"
+#endif
+
+-- | Filter out all of the normal type arguments from a list of 'TypeArg's.
+filterTANormals :: [TypeArg] -> [Type]
+filterTANormals = mapMaybe f
+  where
+    f :: TypeArg -> Maybe Type
+    f (TANormal t) = Just t
+    f (TyArg {})   = Nothing
 
 -- 'NonEmpty' didn't move into base until recently. Reimplementing it locally
 -- saves dependencies for supporting older GHCs
@@ -1240,6 +1362,11 @@ resolveInfixT (ParensT t)       = resolveInfixT t
 resolveInfixT (InfixT l o r)    = conT o `appT` resolveInfixT l `appT` resolveInfixT r
 resolveInfixT (SigT t k)        = SigT <$> resolveInfixT t <*> resolveInfixT k
 resolveInfixT t@UInfixT{}       = resolveInfixT =<< resolveInfixT1 (gatherUInfixT t)
+# if MIN_VERSION_template_haskell(2,15,0)
+resolveInfixT (f `AppKindT` x)  = appKindT (resolveInfixT f) (resolveInfixT x)
+resolveInfixT (ImplicitParamT n t)
+                                = implicitParamT n $ resolveInfixT t
+# endif
 resolveInfixT t                 = return t
 
 gatherUInfixT :: Type -> InfixList
@@ -1398,6 +1525,10 @@ freeVariablesWellScoped tys =
             in case t of
                  VarT n -> Map.insert n k kSigs
                  _      -> go_ty t `mappend` kSigs
+#if MIN_VERSION_template_haskell(2,15,0)
+          go_ty (AppKindT t k) = go_ty t `mappend` go_ty k
+          go_ty (ImplicitParamT _ t) = go_ty t
+#endif
           go_ty _ = mempty
 
           go_pred :: Pred -> Map Name Kind
@@ -1507,6 +1638,11 @@ instance TypeSubstitution Type where
       go (UInfixT l c r) = UInfixT (go l) c (go r)
       go (ParensT t)     = ParensT (go t)
 #endif
+#if MIN_VERSION_template_haskell(2,15,0)
+      go (AppKindT t k)  = AppKindT (go t) (go k)
+      go (ImplicitParamT n t)
+                         = ImplicitParamT n (go t)
+#endif
       go t               = t
 
   freeVariables t =
@@ -1523,6 +1659,11 @@ instance TypeSubstitution Type where
       InfixT l _ r  -> freeVariables l `union` freeVariables r
       UInfixT l _ r -> freeVariables l `union` freeVariables r
       ParensT t'    -> freeVariables t'
+#endif
+#if MIN_VERSION_template_haskell(2,15,0)
+      AppKindT t k  -> freeVariables t `union` freeVariables k
+      ImplicitParamT _ t
+                    -> freeVariables t
 #endif
       _             -> []
 
@@ -1675,25 +1816,22 @@ isn'tReified = False
 -- GADT type variables of kind *. To work around this, we insert the kinds
 -- manually on any types without a signature.
 
-giveTypesStarKinds :: DatatypeInfo -> DatatypeInfo
-giveTypesStarKinds info =
-  info { datatypeVars = annotateVars (datatypeVars info) }
-  where
-    annotateVars :: [Type] -> [Type]
-    annotateVars = map $ \t ->
-      case t of
-        VarT n -> SigT (VarT n) starK
-        _      -> t
+giveDIVarsStarKinds :: DatatypeInfo -> DatatypeInfo
+giveDIVarsStarKinds info =
+  info { datatypeVars      = map giveTyVarBndrStarKind (datatypeVars info)
+       , datatypeInstTypes = map giveTypeStarKind (datatypeInstTypes info) }
 
-giveTyVarBndrsStarKinds :: ConstructorInfo -> ConstructorInfo
-giveTyVarBndrsStarKinds info =
-  info { constructorVars = annotateVars (constructorVars info) }
-  where
-    annotateVars :: [TyVarBndr] -> [TyVarBndr]
-    annotateVars = map $ \tvb ->
-      case tvb of
-        PlainTV n -> KindedTV n starK
-        _         -> tvb
+giveCIVarsStarKinds :: ConstructorInfo -> ConstructorInfo
+giveCIVarsStarKinds info =
+  info { constructorVars = map giveTyVarBndrStarKind (constructorVars info) }
+
+giveTyVarBndrStarKind :: TyVarBndr -> TyVarBndr
+giveTyVarBndrStarKind (PlainTV n)    = KindedTV n starK
+giveTyVarBndrStarKind tvb@KindedTV{} = tvb
+
+giveTypeStarKind :: Type -> Type
+giveTypeStarKind t@(VarT n) = SigT t starK
+giveTypeStarKind t          = t
 
 -- | Prior to GHC 8.2.1, reify was broken for data instances and newtype
 -- instances. This code attempts to detect the problem and repair it if
@@ -1718,7 +1856,7 @@ repair13618 info =
 
   where
     used  = freeVariables (datatypeCons info)
-    bound = freeVariables (datatypeVars info)
+    bound = map tvName (datatypeVars info)
     free  = used \\ bound
 
     substList =
@@ -1775,14 +1913,19 @@ newtypeDCompat = newtypeD
 
 -- | Backward compatible version of 'tySynInstD'
 tySynInstDCompat ::
-  Name    {- ^ type family name    -} ->
-  [TypeQ] {- ^ instance parameters -} ->
-  TypeQ   {- ^ instance result     -} ->
+  Name                {- ^ type family name    -}   ->
+  Maybe [Q TyVarBndr] {- ^ type variable binders -} ->
+  [TypeQ]             {- ^ instance parameters -}   ->
+  TypeQ               {- ^ instance result     -}   ->
   DecQ
-#if MIN_VERSION_template_haskell(2,9,0)
-tySynInstDCompat n ps r = TySynInstD n <$> (TySynEqn <$> sequence ps <*> r)
+#if MIN_VERSION_template_haskell(2,15,0)
+tySynInstDCompat n mtvbs ps r = TySynInstD <$> (TySynEqn <$> mapM sequence mtvbs
+                                                         <*> foldl' appT (conT n) ps
+                                                         <*> r)
+#elif MIN_VERSION_template_haskell(2,9,0)
+tySynInstDCompat n _ ps r     = TySynInstD n <$> (TySynEqn <$> sequence ps <*> r)
 #else
-tySynInstDCompat = tySynInstD
+tySynInstDCompat n _          = tySynInstD n
 #endif
 
 -- | Backward compatible version of 'pragLineD'. Returns

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -1314,11 +1314,11 @@ data TypeArg
 -- | Apply a 'Type' to a 'TypeArg'.
 appTypeArg :: Type -> TypeArg -> Type
 appTypeArg f (TANormal x) = f `AppT` x
-appTypeArg f (TyArg k) =
+appTypeArg f (TyArg _k) =
 #if MIN_VERSION_template_haskell(2,15,0)
-  f `AppKindT` k
+  f `AppKindT` _k
 #else
-  error "Visible kind applications only supported with template-haskell-2.15+"
+  f -- VKA isn't supported, so conservatively drop the argument
 #endif
 
 -- | Filter out all of the normal type arguments from a list of 'TypeArg's.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -92,21 +92,24 @@ adt1Test :: IO ()
 adt1Test =
   $(do info <- reifyDatatype ''Adt1
 
-       let vars@[a,b]  = map (VarT . mkName) ["a","b"]
-           [aSig,bSig] = map (\v -> SigT v starK) vars
+       let names            = map mkName ["a","b"]
+           [aTvb,bTvb]      = map (\v -> KindedTV v starK) names
+           vars@[aVar,bVar] = map (VarT . mkName) ["a","b"]
+           [aSig,bSig]      = map (\v -> SigT v starK) vars
 
        validateDI info
          DatatypeInfo
            { datatypeName = ''Adt1
            , datatypeContext = []
-           , datatypeVars = [aSig, bSig]
+           , datatypeVars = [aTvb,bTvb]
+           , datatypeInstTypes = [aSig, bSig]
            , datatypeVariant = Datatype
            , datatypeCons =
                [ ConstructorInfo
                    { constructorName = 'Adtc1
                    , constructorContext = []
                    , constructorVars = []
-                   , constructorFields = [AppT (AppT (TupleT 2) a) b]
+                   , constructorFields = [AppT (AppT (TupleT 2) aVar) bVar]
                    , constructorStrictness = [notStrictAnnot]
                    , constructorVariant = NormalConstructor }
                , ConstructorInfo
@@ -124,19 +127,21 @@ gadt1Test :: IO ()
 gadt1Test =
   $(do info <- reifyDatatype ''Gadt1
 
-       let a = VarT (mkName "a")
+       let a = mkName "a"
+           aVar = VarT a
 
        validateDI info
          DatatypeInfo
            { datatypeName = ''Gadt1
            , datatypeContext = []
-           , datatypeVars = [SigT a starK]
+           , datatypeVars = [KindedTV a starK]
+           , datatypeInstTypes = [SigT aVar starK]
            , datatypeVariant = Datatype
            , datatypeCons =
                [ ConstructorInfo
                    { constructorName = 'Gadtc1
                    , constructorVars = []
-                   , constructorContext = [equalPred a (ConT ''Int)]
+                   , constructorContext = [equalPred aVar (ConT ''Int)]
                    , constructorFields = [ConT ''Int]
                    , constructorStrictness = [notStrictAnnot]
                    , constructorVariant = NormalConstructor }
@@ -144,20 +149,20 @@ gadt1Test =
                    { constructorName = 'Gadtc2
                    , constructorVars = []
                    , constructorContext = []
-                   , constructorFields = [AppT (AppT (TupleT 2) a) a]
+                   , constructorFields = [AppT (AppT (TupleT 2) aVar) aVar]
                    , constructorStrictness = [notStrictAnnot]
                    , constructorVariant = NormalConstructor }
                , ConstructorInfo
                    { constructorName = '(:**:)
                    , constructorVars = []
-                   , constructorContext = [equalPred a (TupleT 0)]
+                   , constructorContext = [equalPred aVar (TupleT 0)]
                    , constructorFields = [ConT ''Bool, ConT ''Char]
                    , constructorStrictness = [notStrictAnnot, notStrictAnnot]
                    , constructorVariant = InfixConstructor }
                , ConstructorInfo
                    { constructorName = '(:!!:)
                    , constructorVars = []
-                   , constructorContext = [equalPred a (ConT ''Double)]
+                   , constructorContext = [equalPred aVar (ConT ''Double)]
                    , constructorFields = [ConT ''Char, ConT ''Bool]
                    , constructorStrictness = [notStrictAnnot, notStrictAnnot]
                    , constructorVariant = NormalConstructor }
@@ -169,15 +174,17 @@ gadtrec1Test :: IO ()
 gadtrec1Test =
   $(do info <- reifyDatatype ''Gadtrec1
 
-       let con = gadtRecVanillaCI
+       let a   = mkName "a"
+           con = gadtRecVanillaCI
 
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''Gadtrec1
-           , datatypeContext = []
-           , datatypeVars    = [SigT (VarT (mkName "a")) starK]
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeName      = ''Gadtrec1
+           , datatypeContext   = []
+           , datatypeVars      = [KindedTV a starK]
+           , datatypeInstTypes = [SigT (VarT a) starK]
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ con, con { constructorName = 'Gadtrecc2 } ]
            }
    )
@@ -186,23 +193,30 @@ equalTest :: IO ()
 equalTest =
   $(do info <- reifyDatatype ''Equal
 
-       let vars@[a,b,c]     = map (VarT . mkName) ["a","b","c"]
-           [aSig,bSig,cSig] = map (\v -> SigT v starK) vars
+       let names                 = map mkName ["a","b","c"]
+           [aTvb,bTvb,cTvb]      = map (\v -> KindedTV v starK) names
+           vars@[aVar,bVar,cVar] = map VarT names
+           [aSig,bSig,cSig]      = map (\v -> SigT v starK) vars
 
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''Equal
-           , datatypeContext = []
-           , datatypeVars    = [aSig, bSig, cSig]
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeName      = ''Equal
+           , datatypeContext   = []
+           , datatypeVars      = [aTvb, bTvb, cTvb]
+           , datatypeInstTypes = [aSig, bSig, cSig]
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'Equalc
                    , constructorVars       = []
                    , constructorContext    =
-                        [equalPred a c, equalPred b c, classPred ''Read [c], classPred ''Show [c] ]
+                        [ equalPred aVar cVar
+                        , equalPred bVar cVar
+                        , classPred ''Read [cVar]
+                        , classPred ''Show [cVar]
+                        ]
                    , constructorFields     =
-                        [ListT `AppT` c, ConT ''Maybe `AppT` c]
+                        [ListT `AppT` cVar, ConT ''Maybe `AppT` cVar]
                    , constructorStrictness =
                         [notStrictAnnot, notStrictAnnot]
                    , constructorVariant    = NormalConstructor }
@@ -218,11 +232,12 @@ showableTest =
 
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''Showable
-           , datatypeContext = []
-           , datatypeVars    = []
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeName      = ''Showable
+           , datatypeContext   = []
+           , datatypeVars      = []
+           , datatypeInstTypes = []
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'Showable
                    , constructorVars       = [KindedTV a starK]
@@ -239,11 +254,12 @@ recordTest =
   $(do info <- reifyDatatype ''R
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''R
-           , datatypeContext = []
-           , datatypeVars    = []
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeName      = ''R
+           , datatypeContext   = []
+           , datatypeVars      = []
+           , datatypeInstTypes = []
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'R1
                    , constructorVars       = []
@@ -258,10 +274,13 @@ recordTest =
 gadt2Test :: IO ()
 gadt2Test =
   $(do info <- reifyDatatype ''Gadt2
-       let vars@[a,b]  = map (VarT . mkName) ["a","b"]
-           [aSig,bSig] = map (\v -> SigT v starK) vars
-           x     = mkName "x"
-           con   = ConstructorInfo
+       let names            = map mkName ["a","b"]
+           [aTvb,bTvb]      = map (\v -> KindedTV v starK) names
+           vars@[aVar,bVar] = map VarT names
+           [aSig,bSig]      = map (\v -> SigT v starK) vars
+           x                = mkName "x"
+
+           con = ConstructorInfo
                      { constructorName       = undefined
                      , constructorVars       = []
                      , constructorContext    = []
@@ -270,20 +289,21 @@ gadt2Test =
                      , constructorVariant    = NormalConstructor }
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''Gadt2
-           , datatypeContext = []
-           , datatypeVars    = [aSig, bSig]
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeName      = ''Gadt2
+           , datatypeContext   = []
+           , datatypeVars      = [aTvb, bTvb]
+           , datatypeInstTypes = [aSig, bSig]
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ con { constructorName = 'Gadt2c1
-                     , constructorContext = [equalPred b (AppT ListT a)] }
+                     , constructorContext = [equalPred bVar (AppT ListT aVar)] }
                , con { constructorName = 'Gadt2c2
-                     , constructorContext = [equalPred a (AppT ListT b)] }
+                     , constructorContext = [equalPred aVar (AppT ListT bVar)] }
                , con { constructorName = 'Gadt2c3
                      , constructorVars = [KindedTV x starK]
                      , constructorContext =
-                         [equalPred a (AppT ListT (VarT x))
-                         ,equalPred b (AppT ListT (VarT x))] } ]
+                         [equalPred aVar (AppT ListT (VarT x))
+                         ,equalPred bVar (AppT ListT (VarT x))] } ]
            }
   )
 
@@ -293,11 +313,12 @@ voidstosTest =
        let g = mkName "g"
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''VoidStoS
-           , datatypeContext = []
-           , datatypeVars    = [SigT (VarT g) (arrowKCompat starK starK)]
-           , datatypeVariant = Datatype
-           , datatypeCons    = []
+           { datatypeName      = ''VoidStoS
+           , datatypeContext   = []
+           , datatypeVars      = [KindedTV g (arrowKCompat starK starK)]
+           , datatypeInstTypes = [SigT (VarT g) (arrowKCompat starK starK)]
+           , datatypeVariant   = Datatype
+           , datatypeCons      = []
            }
   )
 
@@ -306,11 +327,12 @@ strictDemoTest =
   $(do info <- reifyDatatype ''StrictDemo
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''StrictDemo
-           , datatypeContext = []
-           , datatypeVars    = []
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeName      = ''StrictDemo
+           , datatypeContext   = []
+           , datatypeVars      = []
+           , datatypeInstTypes = []
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'StrictDemo
                    , constructorVars       = []
@@ -336,11 +358,12 @@ t43Test =
        infoPlain  <- normalizeDec decPlain
        validateDI infoPlain
          DatatypeInfo
-           { datatypeName    = mkName "T43Plain"
-           , datatypeContext = []
-           , datatypeVars    = []
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeName      = mkName "T43Plain"
+           , datatypeContext   = []
+           , datatypeVars      = []
+           , datatypeInstTypes = []
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = mkName "MkT43Plain"
                    , constructorVars       = []
@@ -354,11 +377,12 @@ t43Test =
        infoFam  <- normalizeDec decFam
        validateDI infoFam
          DatatypeInfo
-           { datatypeName    = mkName "T43Fam"
-           , datatypeContext = []
-           , datatypeVars    = []
-           , datatypeVariant = DataInstance
-           , datatypeCons    =
+           { datatypeName      = mkName "T43Fam"
+           , datatypeContext   = []
+           , datatypeVars      = []
+           , datatypeInstTypes = []
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = mkName "MkT43Fam"
                    , constructorVars       = []
@@ -377,11 +401,12 @@ dataFamilyTest =
        let a = mkName "a"
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''DF
-           , datatypeContext = []
-           , datatypeVars    = [AppT (ConT ''Maybe) (VarT a)]
-           , datatypeVariant = DataInstance
-           , datatypeCons    =
+           { datatypeName      = ''DF
+           , datatypeContext   = []
+           , datatypeVars      = [KindedTV a starK]
+           , datatypeInstTypes = [AppT (ConT ''Maybe) (VarT a)]
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'DFMaybe
                    , constructorVars       = []
@@ -395,19 +420,21 @@ dataFamilyTest =
 ghc78bugTest :: IO ()
 ghc78bugTest =
   $(do info <- reifyDatatype 'DF1
-       let c = VarT (mkName "c")
+       let c    = mkName "c"
+           cVar = VarT c
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''DF1
-           , datatypeContext = []
-           , datatypeVars    = [SigT c starK]
-           , datatypeVariant = DataInstance
-           , datatypeCons    =
+           { datatypeName      = ''DF1
+           , datatypeContext   = []
+           , datatypeVars      = [KindedTV c starK]
+           , datatypeInstTypes = [SigT cVar starK]
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'DF1
                    , constructorVars       = []
                    , constructorContext    = []
-                   , constructorFields     = [c]
+                   , constructorFields     = [cVar]
                    , constructorStrictness = [notStrictAnnot]
                    , constructorVariant    = NormalConstructor } ]
            }
@@ -417,19 +444,21 @@ quotedTest :: IO ()
 quotedTest =
   $(do [dec] <- [d| data instance Quoted a = MkQuoted a |]
        info  <- normalizeDec dec
-       let a = VarT (mkName "a")
+       let a    = mkName "a"
+           aVar = VarT a
        validateDI info
          DatatypeInfo
-           { datatypeName    = mkName "Quoted"
-           , datatypeContext = []
-           , datatypeVars    = [SigT a starK]
-           , datatypeVariant = DataInstance
-           , datatypeCons    =
+           { datatypeName      = mkName "Quoted"
+           , datatypeContext   = []
+           , datatypeVars      = [KindedTV a starK]
+           , datatypeInstTypes = [SigT aVar starK]
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = mkName "MkQuoted"
                    , constructorVars       = []
                    , constructorContext    = []
-                   , constructorFields     = [a]
+                   , constructorFields     = [aVar]
                    , constructorStrictness = [notStrictAnnot]
                    , constructorVariant    = NormalConstructor } ]
            }
@@ -439,13 +468,19 @@ polyTest :: IO ()
 polyTest =
   $(do info <- reifyDatatype 'MkPoly
        let [a,k] = map mkName ["a","k"]
+           kVar  = varKCompat k
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''Poly
-           , datatypeContext = []
-           , datatypeVars    = [SigT (VarT a) (varKCompat k)]
-           , datatypeVariant = DataInstance
-           , datatypeCons    =
+           { datatypeName      = ''Poly
+           , datatypeContext   = []
+           , datatypeVars      = [
+#if __GLASGOW_HASKELL__ >= 800
+                                 KindedTV k starK,
+#endif
+                                 KindedTV a kVar ]
+           , datatypeInstTypes = [SigT (VarT a) kVar]
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'MkPoly
                    , constructorVars       = []
@@ -459,16 +494,18 @@ polyTest =
 gadtFamTest :: IO ()
 gadtFamTest =
   $(do info <- reifyDatatype 'MkGadtFam1
-       let names@[c,d,e,q]   = map mkName ["c","d","e","q"]
-           [cTy,dTy,eTy,qTy] = map VarT names
-           [cSig,dSig]       = map (\v -> SigT v starK) [cTy,dTy]
+       let names@[c,d,e,q]       = map mkName ["c","d","e","q"]
+           [cTvb,dTvb,eTvb,qTvb] = map (\v -> KindedTV v starK) names
+           [cTy,dTy,eTy,qTy]     = map VarT names
+           [cSig,dSig]           = map (\v -> SigT v starK) [cTy,dTy]
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''GadtFam
-           , datatypeContext = []
-           , datatypeVars    = [cSig,dSig]
-           , datatypeVariant = DataInstance
-           , datatypeCons    =
+           { datatypeName      = ''GadtFam
+           , datatypeContext   = []
+           , datatypeVars      = [cTvb,dTvb]
+           , datatypeInstTypes = [cSig,dSig]
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'MkGadtFam1
                    , constructorVars       = []
@@ -521,11 +558,12 @@ famLocalDecTest1 =
        info <- normalizeDec dec
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''FamLocalDec1
-           , datatypeContext = []
-           , datatypeVars    = [ConT ''Int]
-           , datatypeVariant = DataInstance
-           , datatypeCons    =
+           { datatypeName      = ''FamLocalDec1
+           , datatypeContext   = []
+           , datatypeVars      = []
+           , datatypeInstTypes = [ConT ''Int]
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = mkName "FamLocalDec1Int"
                    , constructorVars       = []
@@ -540,20 +578,23 @@ famLocalDecTest2 :: IO ()
 famLocalDecTest2 =
   $(do [dec] <- [d| data instance FamLocalDec2 Int (a, b) a = FamLocalDec2Int { fm0 :: (b, a), fm1 :: Int } |]
        info <- normalizeDec dec
-       let tys@[a,b]   = map (VarT . mkName) ["a", "b"]
-           [aSig,bSig] = map (\v -> SigT v starK) tys
+       let names            = map mkName ["a", "b"]
+           [aTvb,bTvb]      = map (\v -> KindedTV v starK) names
+           vars@[aVar,bVar] = map (VarT . mkName) ["a", "b"]
+           [aSig,bSig]      = map (\v -> SigT v starK) vars
        validateDI info
          DatatypeInfo
-           { datatypeName    = ''FamLocalDec2
-           , datatypeContext = []
-           , datatypeVars    = [ConT ''Int, TupleT 2 `AppT` a `AppT` b, aSig]
-           , datatypeVariant = DataInstance
-           , datatypeCons    =
+           { datatypeName      = ''FamLocalDec2
+           , datatypeContext   = []
+           , datatypeVars      = [aTvb,bTvb]
+           , datatypeInstTypes = [ConT ''Int, TupleT 2 `AppT` aVar `AppT` bVar, aSig]
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = mkName "FamLocalDec2Int"
                    , constructorVars       = []
                    , constructorContext    = []
-                   , constructorFields     = [TupleT 2 `AppT` b `AppT` a, ConT ''Int]
+                   , constructorFields     = [TupleT 2 `AppT` bVar `AppT` aVar, ConT ''Int]
                    , constructorStrictness = [notStrictAnnot, notStrictAnnot]
                    , constructorVariant    = RecordConstructor [mkName "fm0", mkName "fm1"] }]
            }
@@ -597,13 +638,15 @@ resolvePredSynonymsTest =
 reifyDatatypeWithConNameTest :: IO ()
 reifyDatatypeWithConNameTest =
   $(do info <- reifyDatatype 'Just
+       let a = mkName "a"
        validateDI info
          DatatypeInfo
-          { datatypeContext = []
-          , datatypeName    = ''Maybe
-          , datatypeVars    = [SigT (VarT (mkName "a")) starK]
-          , datatypeVariant = Datatype
-          , datatypeCons    =
+          { datatypeContext   = []
+          , datatypeName      = ''Maybe
+          , datatypeVars      = [KindedTV a starK]
+          , datatypeInstTypes = [SigT (VarT a) starK]
+          , datatypeVariant   = Datatype
+          , datatypeCons      =
               [ ConstructorInfo
                   { constructorName       = 'Nothing
                   , constructorVars       = []
@@ -626,20 +669,26 @@ reifyConstructorTest =
 importedEqualityTest :: IO ()
 importedEqualityTest =
   $(do info <- reifyDatatype ''(:~:)
-       let [a,b] = map (VarT . mkName) ["a","b"]
-           k     = mkName "k"
-           kKind = varKCompat k
+       let names@[a,b] = map mkName ["a","b"]
+           [aVar,bVar] = map VarT names
+           k           = mkName "k"
+           kKind       = varKCompat k
        validateDI info
          DatatypeInfo
-           { datatypeContext = []
-           , datatypeName    = ''(:~:)
-           , datatypeVars    = [SigT a kKind, SigT b kKind]
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeContext   = []
+           , datatypeName      = ''(:~:)
+           , datatypeVars      = [
+#if __GLASGOW_HASKELL__ >= 800
+                                 KindedTV k starK,
+#endif
+                                 KindedTV a kKind, KindedTV b kKind]
+           , datatypeInstTypes = [SigT aVar kKind, SigT bVar kKind]
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'Refl
                    , constructorVars       = []
-                   , constructorContext    = [equalPred a b]
+                   , constructorContext    = [equalPred aVar bVar]
                    , constructorFields     = []
                    , constructorStrictness = []
                    , constructorVariant    = NormalConstructor } ]
@@ -722,18 +771,24 @@ t61Test =
 t37Test :: IO ()
 t37Test =
   $(do infoA <- reifyDatatype ''T37a
-       let [k,a] = map (VarT . mkName) ["k","a"]
+       let names@[k,a] = map mkName ["k","a"]
+           [kVar,aVar] = map VarT names
+           kSig        = SigT kVar starK
+           aSig        = SigT aVar kVar
+           kTvb        = KindedTV k starK
+           aTvb        = KindedTV a kVar
        validateDI infoA
          DatatypeInfo
-           { datatypeContext = []
-           , datatypeName    = ''T37a
-           , datatypeVars    = [SigT k starK, SigT a k]
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeContext   = []
+           , datatypeName      = ''T37a
+           , datatypeVars      = [kTvb, aTvb]
+           , datatypeInstTypes = [kSig, aSig]
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'MkT37a
                    , constructorVars       = []
-                   , constructorContext    = [equalPred k (ConT ''Bool)]
+                   , constructorContext    = [equalPred kVar (ConT ''Bool)]
                    , constructorFields     = []
                    , constructorStrictness = []
                    , constructorVariant    = NormalConstructor } ]
@@ -742,15 +797,16 @@ t37Test =
        infoB <- reifyDatatype ''T37b
        validateDI infoB
          DatatypeInfo
-           { datatypeContext = []
-           , datatypeName    = ''T37b
-           , datatypeVars    = [SigT a k]
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeContext   = []
+           , datatypeName      = ''T37b
+           , datatypeVars      = [kTvb, aTvb]
+           , datatypeInstTypes = [aSig]
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'MkT37b
                    , constructorVars       = []
-                   , constructorContext    = [equalPred k (ConT ''Bool)]
+                   , constructorContext    = [equalPred kVar (ConT ''Bool)]
                    , constructorFields     = []
                    , constructorStrictness = []
                    , constructorVariant    = NormalConstructor } ]
@@ -759,15 +815,16 @@ t37Test =
        infoC <- reifyDatatype ''T37c
        validateDI infoC
          DatatypeInfo
-           { datatypeContext = []
-           , datatypeName    = ''T37c
-           , datatypeVars    = [SigT a k]
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeContext   = []
+           , datatypeName      = ''T37c
+           , datatypeVars      = [kTvb, aTvb]
+           , datatypeInstTypes = [aSig]
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'MkT37c
                    , constructorVars       = []
-                   , constructorContext    = [equalPred a (ConT ''Bool)]
+                   , constructorContext    = [equalPred aVar (ConT ''Bool)]
                    , constructorFields     = []
                    , constructorStrictness = []
                    , constructorVariant    = NormalConstructor } ]
@@ -778,16 +835,18 @@ polyKindedExTyvarTest :: IO ()
 polyKindedExTyvarTest =
   $(do info <- reifyDatatype ''T48
        let [a,x] = map mkName ["a","x"]
+           aVar  = VarT a
        validateDI info
          DatatypeInfo
-           { datatypeContext = []
-           , datatypeName    = ''T48
-           , datatypeVars    = [SigT (VarT a) starK]
-           , datatypeVariant = Datatype
-           , datatypeCons    =
+           { datatypeContext   = []
+           , datatypeName      = ''T48
+           , datatypeVars      = [KindedTV a starK]
+           , datatypeInstTypes = [SigT aVar starK]
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'MkT48
-                   , constructorVars       = [KindedTV x (VarT a)]
+                   , constructorVars       = [KindedTV x aVar]
                    , constructorContext    = []
                    , constructorFields     = [ConT ''Prox `AppT` VarT x]
                    , constructorStrictness = [notStrictAnnot]
@@ -798,7 +857,7 @@ polyKindedExTyvarTest =
        -- unfortunately does not check if the uses of `a` in datatypeVars and
        -- constructorVars are the same. We perform this check explicitly here.
        case info of
-         DatatypeInfo { datatypeVars = [SigT (VarT a1) starK]
+         DatatypeInfo { datatypeVars = [KindedTV a1 starK]
                       , datatypeCons =
                           [ ConstructorInfo
                               { constructorVars = [KindedTV _ (VarT a2)] } ] } ->

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,11 @@
 {-# LANGUAGE ConstraintKinds #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 807
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+#endif
+
 #if MIN_VERSION_template_haskell(2,8,0)
 {-# Language PolyKinds #-}
 #endif
@@ -84,6 +89,9 @@ main =
 #if __GLASGOW_HASKELL__ >= 800
      t37Test
      polyKindedExTyvarTest
+#endif
+#if __GLASGOW_HASKELL__ >= 807
+     resolveTypeSynonymsVKATest
 #endif
      regressionTest44
      t63Test
@@ -866,6 +874,17 @@ polyKindedExTyvarTest =
                  ++ show [a1, a2]
        [| return () |]
    )
+#endif
+
+#if __GLASGOW_HASKELL__ >= 807
+resolveTypeSynonymsVKATest :: IO ()
+resolveTypeSynonymsVKATest =
+  $(do t  <- [t| T37b @Bool True |]
+       t' <- resolveTypeSynonyms t
+       unless (t == t') $
+         fail $ "Type synonym expansion breaks with visible kind application: "
+            ++ show [t, t']
+       [| return () |])
 #endif
 
 regressionTest44 :: IO ()

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -1,5 +1,5 @@
 name:                th-abstraction
-version:             0.2.10.0
+version:             0.3.0.0
 synopsis:            Nicer interface for reified information about data types
 description:         This package normalizes variations in the interface for
                      inspecting datatype information via Template Haskell


### PR DESCRIPTION
This is a WIP patch for #55 that:

1. Accommodates the new `TyVarBndr` information that is provided for data family instances in `template-haskell-2.15`. To accomplish this, we change the type of `datatypeVars` from `[Type]` to `[TyVarBndr]`, and give the old `datatypeVars` field the new name `datatypeInstVars`.
2. Adds support for new `Type` forms in `template-haskell-2.15`, like `AppKindT` (for visible kind application) and `ImplicitParamT` (for implicit params).

Don't merge this yet—this patch assumes some changes to GHC HEAD which have [yet to land](https://phabricator.haskell.org/D5229). I'm only opening this PR now to get feedback on the design.