### PR TITLE
Fix #58

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@
   In addition, the type of `normalizeCon` now has an additional `[TyVarBndr]`
   argument, since `DatatypeInfo` now requires it.
 * Support `template-haskell-2.15`.
+* Fix a bug in which `normalizeDec` would not detect existential type variables
+  in a GADT constructor if they were implicitly quantified.
 
 ## 0.2.10.0 -- 2018-12-20
 * Optimization: `quantifyType` now collapses consecutive `forall`s. For

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -986,7 +986,7 @@ normalizeGadtC typename params instTys tyvars context names innerType
      -- constructor-bound variables before proceeding. See #36 for an example
      -- of what can go wrong if this isn't done.
      let conBoundNames =
-           concatMap (\tvb -> tvName tvb:freeVariables (tvKind tvb)) tyvars
+           concatMap (\tvb -> tvName tvb:freeVariables (tvKind tvb)) allTyvars
      conSubst <- T.sequence $ Map.fromList [ (n, newName (nameBase n))
                                            | n <- conBoundNames ]
      let conSubst'     = fmap VarT conSubst

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -60,6 +60,7 @@ main =
      recordVanillaTest
 #if MIN_VERSION_template_haskell(2,6,0)
      t43Test
+     t58Test
 #endif
 #if MIN_VERSION_template_haskell(2,7,0)
      dataFamilyTest
@@ -397,6 +398,30 @@ t43Test =
                    , constructorContext    = []
                    , constructorFields     = []
                    , constructorStrictness = []
+                   , constructorVariant    = NormalConstructor } ]
+           }
+   )
+
+t58Test :: IO ()
+t58Test =
+  $(do [dec] <- [d| data Foo where
+                      MkFoo :: a -> Foo |]
+       info <- normalizeDec dec
+       let a = mkName "a"
+       validateDI info
+         DatatypeInfo
+           { datatypeName      = mkName "Foo"
+           , datatypeContext   = []
+           , datatypeVars      = []
+           , datatypeInstTypes = []
+           , datatypeVariant   = Datatype
+           , datatypeCons      =
+               [ ConstructorInfo
+                   { constructorName       = mkName "MkFoo"
+                   , constructorVars       = [KindedTV a starK]
+                   , constructorContext    = []
+                   , constructorFields     = [VarT a]
+                   , constructorStrictness = [notStrictAnnot]
                    , constructorVariant    = NormalConstructor } ]
            }
    )


### PR DESCRIPTION
It's possible that by the time we reach `normalizeGadtC`, there are still type variables for which we do not have `TyVarBndr`s, which results in existential type variables not being detected properly. This addresses the issue by using `freeVariablesWellScoped` to obtain all type variable binders before proceeding further.