### PR TITLE
Fix #66 by introducing mkExtraKindBinders 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@
 * Support `template-haskell-2.15`.
 * Fix a bug in which `normalizeDec` would not detect existential type variables
   in a GADT constructor if they were implicitly quantified.
+* Fix a bug in which `normalizeDec` would report an incorrect number of
+  `datatypeVars` for GADT declarations with explicit return kinds (such as
+  `data Foo :: * -> * where`).
 
 ## 0.2.10.0 -- 2018-12-20
 * Optimization: `quantifyType` now collapses consecutive `forall`s. For

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -672,11 +672,22 @@ normalizeDecFor isReified dec =
       | otherwise
       = return di
 
+    -- Given a data type's instance types and kind, compute its free variables.
+    datatypeFreeVars :: [Type] -> Maybe Kind -> [TyVarBndr]
+    datatypeFreeVars instTys mbKind =
+      freeVariablesWellScoped $ instTys ++
+#if MIN_VERSION_template_haskell(2,8,0)
+                                           maybeToList mbKind
+#else
+                                           [] -- No kind variables
+#endif
+
     normalizeDataD :: Cxt -> Name -> [TyVarBndr] -> Maybe Kind
                    -> [Con] -> DatatypeVariant -> Q DatatypeInfo
-    normalizeDataD context name tyvars =
+    normalizeDataD context name tyvars mbKind cons variant =
       let params = bndrParams tyvars in
-      normalize' context name (freeVariablesWellScoped params) params
+      normalize' context name (datatypeFreeVars params mbKind)
+                 params mbKind cons variant
 
     normalizeDataInstDPostTH2'15
       :: String -> Cxt -> Maybe [TyVarBndr] -> Type -> Maybe Kind
@@ -685,22 +696,48 @@ normalizeDecFor isReified dec =
                                  mbKind cons variant =
       case decomposeType nameInstTys of
         ConT name :| instTys ->
-          normalize' context name (fromMaybe (freeVariablesWellScoped instTys) mbTyvars) instTys
-                     mbKind cons variant
+          normalize' context name
+                     (fromMaybe (datatypeFreeVars instTys mbKind) mbTyvars)
+                     instTys mbKind cons variant
         _ -> fail $ "Unexpected " ++ what ++ " instance head: " ++ pprint nameInstTys
 
     normalizeDataInstDPreTH2'15
       :: Cxt -> Name -> [Type] -> Maybe Kind
       -> [Con] -> DatatypeVariant -> Q DatatypeInfo
-    normalizeDataInstDPreTH2'15 context name instTys =
-      normalize' context name (freeVariablesWellScoped instTys) instTys
+    normalizeDataInstDPreTH2'15 context name instTys mbKind cons variant =
+      normalize' context name (datatypeFreeVars instTys mbKind)
+                 instTys mbKind cons variant
 
     -- The main worker of this function.
     normalize' :: Cxt -> Name -> [TyVarBndr] -> [Type] -> Maybe Kind
                -> [Con] -> DatatypeVariant -> Q DatatypeInfo
-    normalize' context name tvbs instTys _mbKind cons variant = do
-      dec <- normalizeDec' isReified context name tvbs instTys cons variant
+    normalize' context name tvbs instTys mbKind cons variant = do
+      extra_tvbs <- mkExtraKindBinders $ fromMaybe starK mbKind
+      let tvbs'    = tvbs ++ extra_tvbs
+          instTys' = instTys ++ bndrParams extra_tvbs
+      dec <- normalizeDec' isReified context name tvbs' instTys' cons variant
       repair13618' $ giveDIVarsStarKinds dec
+
+-- | Create new kind variable binder names corresponding to the return kind of
+-- a data type. This is useful when you have a data type like:
+--
+-- @
+-- data Foo :: forall k. k -> Type -> Type where ...
+-- @
+--
+-- But you want to be able to refer to the type @Foo a b@.
+-- 'mkExtraKindBinders' will take the kind @forall k. k -> Type -> Type@,
+-- discover that is has two visible argument kinds, and return as a result
+-- two new kind variable binders @[a :: k, b :: Type]@, where @a@ and @b@
+-- are fresh type variable names.
+--
+-- This expands kind synonyms if necessary.
+mkExtraKindBinders :: Kind -> Q [TyVarBndr]
+mkExtraKindBinders kind = do
+  kind' <- resolveKindSynonyms kind
+  let (_, _, args :|- _) = uncurryKind kind'
+  names <- replicateM (length args) (newName "x")
+  return $ zipWith KindedTV names args
 
 -- | Is a declaration for a @data instance@ or @newtype instance@?
 isFamInstVariant :: DatatypeVariant -> Bool
@@ -1375,7 +1412,7 @@ data NonEmpty a = a :| [a]
 data NonEmptySnoc a = [a] :|- a
 
 -- Decompose a function type into its context, argument types,
--- and return types. For instance, this
+-- and return type. For instance, this
 --
 --   forall a b. (Show a, b ~ Int) => (a -> b) -> Char -> Int
 --
@@ -1388,6 +1425,24 @@ uncurryType = go [] [] []
     go tvbs ctxt args (AppT (AppT ArrowT t1) t2) = go tvbs ctxt (t1:args) t2
     go tvbs ctxt args (ForallT tvbs' ctxt' t)    = go (tvbs++tvbs') (ctxt++ctxt') args t
     go tvbs ctxt args t                          = (tvbs, ctxt, reverse args :|- t)
+
+-- | Decompose a function kind into its context, argument kinds,
+-- and return kind. For instance, this
+--
+--  forall a b. Maybe a -> Maybe b -> Type
+--
+-- becomes
+--
+--   ([a, b], [], [Maybe a, Maybe b] :|- Type)
+uncurryKind :: Kind -> ([TyVarBndr], Cxt, NonEmptySnoc Kind)
+#if MIN_VERSION_template_haskell(2,8,0)
+uncurryKind = uncurryType
+#else
+uncurryKind = go []
+  where
+    go args (ArrowK k1 k2) = go (k1:args) k2
+    go args StarK          = ([], [], reverse args :|- StarK)
+#endif
 
 -- Reconstruct a function type from its type variable binders, context,
 -- argument types and return type.


### PR DESCRIPTION
`normalizeDec` might be given a declaration like this:

```haskell
data Foo :: Type -> Type
```

The TH AST will claim that this has no `TyVarBndr`s, but there actually is one: it's hidden in the return kind! I define a `mkExtraKindBinders` function to flush it out so that the `DatatypeInfo` reports it properly.