### PR TITLE
Make freeVariablesWellScoped sort independently of unique order

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,8 @@
 * Fix a bug in which `normalizeDec` would report an incorrect number of
   `datatypeVars` for GADT declarations with explicit return kinds (such as
   `data Foo :: * -> * where`).
+* Fix a bug in which `freeVariablesWellScoped` would sometimes not preserve
+  the left-to-right ordering of `Name`s generated with `newName`.
 
 ## 0.2.10.0 -- 2018-12-20
 * Optimization: `quantifyType` now collapses consecutive `forall`s. For

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -97,6 +97,7 @@ main =
 #endif
      regressionTest44
      t63Test
+     t70Test
 
 adt1Test :: IO ()
 adt1Test =
@@ -961,4 +962,28 @@ t63Test =
              ++ unlines [ "Expected: " ++ pprint expected
                         , "Actual:   " ++ pprint actual
                         ]
+       [| return () |])
+
+t70Test :: IO ()
+t70Test =
+  $(do a <- newName "a"
+       b <- newName "b"
+       let [aVar, bVar] = map VarT    [a, b]
+           [aTvb, bTvb] = map PlainTV [a, b]
+       let fvsABExpected = [aTvb, bTvb]
+           fvsABActual   = freeVariablesWellScoped [aVar, bVar]
+
+           fvsBAExpected = [bTvb, aTvb]
+           fvsBAActual   = freeVariablesWellScoped [bVar, aVar]
+
+           check expected actual =
+             unless (expected == actual) $
+               fail $ "freeVariablesWellScoped does not preserve left-to-right order: "
+                   ++ unlines [ "Expected: " ++ pprint expected
+                              , "Actual:   " ++ pprint actual
+                              ]
+
+       check fvsABExpected fvsABActual
+       check fvsBAExpected fvsBAActual
+
        [| return () |])


### PR DESCRIPTION
Previously, `freeVariablesWellScoped` was performing a topological sort on a graph constructed from the `graphFromEdges` function in the `containers` library, which relies on the `Ord Name` instance to work. (See #70 for why this is dodgy.) In this patch, I replace this component of `freeVariablesWellScoped` with `scopedSort`, a deterministic function which mimics the topological sorting without relying on the `Ord Name` instance. (`scopedSort`'s implementation is cargo-culted from the function of the same name in the GHC source code.)

Fixes #70.