### PR TITLE
Fix #75

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for th-abstraction
 
+## next -- ????-??-??
+* Fix a bug in which the `TypeSubstitution ConstructorInfo` instance would not
+  detect free kind variables in the `constructorVars`.
+
 ## 0.3.1.0 -- 2019-04-28
 * Fix a bug which would cause data family information to be reified incorrectly
   with GHC 8.8+ in some situations.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -952,6 +952,24 @@ polyKindedExTyvarTest =
                  ++ show [a1, a2]
        [| return () |]
    )
+
+t75Test :: IO ()
+t75Test =
+  $(do info <- reifyDatatype ''T75
+       case datatypeCons info of
+         [c] -> let datatypeVarTypes    = map (VarT . tvName) $ datatypeVars info
+                    constructorVarKinds = map tvKind $ constructorVars c in
+                unless (datatypeVarTypes == constructorVarKinds) $
+                  fail $ "Mismatch between datatypeVars and constructorVars' kinds: "
+                      ++ unlines [ "datatypeVars:           "
+                                     ++ pprint datatypeVarTypes
+                                 , "constructorVars' kinds: "
+                                     ++ pprint constructorVarKinds
+                                 ]
+         cs  -> fail $ "Unexpected number of constructors for T75: "
+                    ++ show (length cs)
+       [| return () |]
+   )
 #endif
 
 #if __GLASGOW_HASKELL__ >= 807

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -139,6 +139,9 @@ data Prox (a :: k) = Prox
 
 data T48 :: Type -> Type where
   MkT48 :: forall a (x :: a). Prox x -> T48 a
+
+data T75 (k :: Type) where
+  MkT75 :: forall k (a :: k). Prox a -> T75 k
 #endif
 
 -- We must define these here due to Template Haskell staging restrictions


### PR DESCRIPTION
Go into the kinds of `constructorVars` when implementing `freeVariables` and `applySubstitution` in the `TypeSubstitution ConstructorInfo` instance. Fixes #75.