### PR TITLE
Support ForallVisT, fix #79

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 # Revision history for th-abstraction
 
 ## next -- ????-??-??
+* Support substituting into and extracting free variables from `ForallVisT`s
+  on `template-haskell-2.16.0.0` (GHC 8.10) or later.
+* Fix a bug in which `freeVariables` could report duplicate kind variables when
+  they occur in the kinds of the type variable binders in a `ForallT`.
+* Fix a bug in which `resolveInfixT` would not resolve `UInfixT`s occurring in
+  the kinds of type variable binders in a `ForallT`.
 * Fix a bug in which the `TypeSubstitution ConstructorInfo` instance would not
   detect free kind variables in the `constructorVars`.
 

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -1,4 +1,4 @@
-{-# Language CPP, FlexibleContexts, TypeFamilies, KindSignatures, TemplateHaskell, GADTs, ScopedTypeVariables #-}
+{-# Language CPP, FlexibleContexts, TypeFamilies, KindSignatures, TemplateHaskell, GADTs, ScopedTypeVariables, TypeOperators #-}
 
 #if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE ConstraintKinds #-}
@@ -67,6 +67,8 @@ data Gadt2 :: * -> * -> * where
 data VoidStoS (f :: * -> *)
 
 data StrictDemo = StrictDemo Int !Int {-# UNPACK #-} !Int
+
+type (:+:) = Either
 
 -- Data families
 data family T43Fam


### PR DESCRIPTION
`template-haskell-2.16.0.0` (bundled with GHC 8.10.1) introduces a `ForallVisT` constructor to represent visible dependent quantification. This patch updates the machinery in `th-abstraction` to handle `ForallVisT`. Most of the lines of code added are copy-pasted from the code that handles `ForallT`.

While writing this patch I noticed #79, so this patch fixes #79 as well.