### PR TITLE
Adapt to explicit specificity

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,20 @@
 # Revision history for th-abstraction
 
+## 0.4.0.0 -- ????-??-??
+* Adapt to the `TyVarBndr` data type gaining a new `flag` type parameter
+  (in `template-haskell-2.17.0.0`) to represent its specificity:
+  * Introduce a new `Language.Haskell.TH.Datatype.TyVarBndr` module that
+    defines `TyVarBndr_`, a backwards-compatible type synonym for `TyVarBndr`,
+    as well as backporting `TyVarBndrSpec`, `TyVarBndrUnit`, and `Specificity`.
+    This module also defines other useful functions for constructing and
+    manipulating `TyVarBndr`s.
+  * The types in `Language.Haskell.TH.Datatype` now use `TyVarBndr_`,
+    `TyVarBndrUnit`, and `TyVarBndrSpec` where appropriate. Technically, this
+    is not a breaking change, since all three are simple type synonyms around
+    `TyVarBndr`, but it is likely that you will need to update your
+    `th-abstraction`-using code anyway if it involves a `TyVarBndr`-consuming
+    function.
+
 ## 0.3.2.0 -- 2020-02-06
 * Support substituting into and extracting free variables from `ForallVisT`s
   on `template-haskell-2.16.0.0` (GHC 8.10) or later.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Eric Mertens
+Copyright (c) 2017-2020 Eric Mertens
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice

--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -15,9 +15,7 @@ module Language.Haskell.TH.Datatype.Internal where
 import Language.Haskell.TH.Syntax
 
 eqTypeName :: Name
-#if MIN_VERSION_base(4,9,0) && __GLASGOW_HASKELL__ < 807
-  -- TODO: Replace __GLASGOW_HASKELL__ < 807 with
-  -- !(MIN_VERSION_base(4,13,0)) once base-4.13 exists
+#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,13,0))
 eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"
 #else
 eqTypeName = mkNameG_tc "ghc-prim" "GHC.Types" "~"

--- a/src/Language/Haskell/TH/Datatype/TyVarBndr.hs
+++ b/src/Language/Haskell/TH/Datatype/TyVarBndr.hs
@@ -1,0 +1,342 @@
+{-# Language CPP, DeriveDataTypeable #-}
+
+#if MIN_VERSION_base(4,4,0)
+#define HAS_GENERICS
+{-# Language DeriveGeneric #-}
+#endif
+
+{-|
+Module      : Language.Haskell.TH.Datatype.TyVarBndr
+Description : Backwards-compatible type variable binders
+Copyright   : Eric Mertens 2020
+License     : ISC
+Maintainer  : emertens@gmail.com
+
+This module provides a backwards-compatible API for constructing and
+manipulating 'TyVarBndr's across multiple versions of the @template-haskell@
+package.
+
+-}
+module Language.Haskell.TH.Datatype.TyVarBndr (
+    -- * @TyVarBndr@-related types
+    TyVarBndr_
+  , TyVarBndrUnit
+  , TyVarBndrSpec
+  , Specificity(..)
+
+    -- * Constructing @TyVarBndr@s
+    -- ** @flag@-polymorphic
+  , plainTVFlag
+  , kindedTVFlag
+    -- ** @TyVarBndrUnit@
+  , plainTV
+  , kindedTV
+    -- ** @TyVarBndrSpec@
+  , plainTVInferred
+  , plainTVSpecified
+  , kindedTVInferred
+  , kindedTVSpecified
+
+    -- * Constructing @Specificity@
+  , inferredSpec
+  , specifiedSpec
+
+    -- * Modifying @TyVarBndr@s
+  , elimTV
+  , mapTV
+  , mapTVName
+  , mapTVFlag
+  , mapTVKind
+  , traverseTV
+  , traverseTVName
+  , traverseTVFlag
+  , traverseTVKind
+  , mapMTV
+  , mapMTVName
+  , mapMTVFlag
+  , mapMTVKind
+  , changeTVFlags
+
+    -- * Properties of @TyVarBndr@s
+  , tvName
+  , tvKind
+  ) where
+
+import Control.Applicative
+import Control.Monad
+import Data.Data (Typeable, Data)
+import Language.Haskell.TH.Lib
+import Language.Haskell.TH.Syntax
+
+#ifdef HAS_GENERICS
+import GHC.Generics (Generic)
+#endif
+
+-- | A type synonym for 'TyVarBndr'. This is the recommended way to refer to
+-- 'TyVarBndr's if you wish to achieve backwards compatibility with older
+-- versions of @template-haskell@, where 'TyVarBndr' lacked a @flag@ type
+-- parameter representing its specificity (if it has one).
+#if MIN_VERSION_template_haskell(2,17,0)
+type TyVarBndr_ flag = TyVarBndr flag
+#else
+type TyVarBndr_ flag = TyVarBndr
+
+-- | A 'TyVarBndr' where the specificity is irrelevant. This is used for
+-- 'TyVarBndr's that do not interact with visible type application.
+type TyVarBndrUnit = TyVarBndr
+
+-- | A 'TyVarBndr' with an explicit 'Specificity'. This is used for
+-- 'TyVarBndr's that interact with visible type application.
+type TyVarBndrSpec = TyVarBndr
+
+-- | Determines how a 'TyVarBndr' interacts with visible type application.
+data Specificity
+  = SpecifiedSpec -- ^ @a@. Eligible for visible type application.
+  | InferredSpec  -- ^ @{a}@. Not eligible for visible type application.
+  deriving (Show, Eq, Ord, Typeable, Data
+#ifdef HAS_GENERICS
+           ,Generic
+#endif
+           )
+
+inferredSpec :: Specificity
+inferredSpec = InferredSpec
+
+specifiedSpec :: Specificity
+specifiedSpec = SpecifiedSpec
+#endif
+
+-- | Construct a 'PlainTV' with the given @flag@.
+plainTVFlag :: Name -> flag -> TyVarBndr_ flag
+#if MIN_VERSION_template_haskell(2,17,0)
+plainTVFlag = PlainTV
+#else
+plainTVFlag n _ = PlainTV n
+#endif
+
+-- | Construct a 'PlainTV' with an 'InferredSpec'.
+plainTVInferred :: Name -> TyVarBndrSpec
+plainTVInferred n = plainTVFlag n InferredSpec
+
+-- | Construct a 'PlainTV' with a 'SpecifiedSpec'.
+plainTVSpecified :: Name -> TyVarBndrSpec
+plainTVSpecified n = plainTVFlag n SpecifiedSpec
+
+-- | Construct a 'KindedTV' with the given @flag@.
+kindedTVFlag :: Name -> flag -> Kind -> TyVarBndr_ flag
+#if MIN_VERSION_template_haskell(2,17,0)
+kindedTVFlag = KindedTV
+#else
+kindedTVFlag n _ kind = KindedTV n kind
+#endif
+
+-- | Construct a 'KindedTV' with an 'InferredSpec'.
+kindedTVInferred :: Name -> Kind -> TyVarBndrSpec
+kindedTVInferred n k = kindedTVFlag n InferredSpec k
+
+-- | Construct a 'KindedTV' with a 'SpecifiedSpec'.
+kindedTVSpecified :: Name -> Kind -> TyVarBndrSpec
+kindedTVSpecified n k = kindedTVFlag n SpecifiedSpec k
+
+-- | Case analysis for a 'TyVarBndr'. If the value is a @'PlainTV' n _@, apply
+-- the first function to @n@; if it is @'KindedTV' n _ k@, apply the second
+-- function to @n@ and @k@.
+elimTV :: (Name -> r) -> (Name -> Kind -> r) -> TyVarBndr_ flag -> r
+#if MIN_VERSION_template_haskell(2,17,0)
+elimTV ptv _ktv (PlainTV n _)    = ptv n
+elimTV _ptv ktv (KindedTV n _ k) = ktv n k
+#else
+elimTV ptv _ktv (PlainTV n)    = ptv n
+elimTV _ptv ktv (KindedTV n k) = ktv n k
+#endif
+
+-- | Map over the components of a 'TyVarBndr'.
+mapTV :: (Name -> Name) -> (flag -> flag') -> (Kind -> Kind)
+      -> TyVarBndr_ flag -> TyVarBndr_ flag'
+#if MIN_VERSION_template_haskell(2,17,0)
+mapTV fn fflag _fkind (PlainTV  n flag)      = PlainTV  (fn n) (fflag flag)
+mapTV fn fflag  fkind (KindedTV n flag kind) = KindedTV (fn n) (fflag flag) (fkind kind)
+#else
+mapTV fn _fflag _fkind (PlainTV  n)      = PlainTV  (fn n)
+mapTV fn _fflag  fkind (KindedTV n kind) = KindedTV (fn n) (fkind kind)
+#endif
+
+-- | Map over the 'Name' of a 'TyVarBndr'.
+mapTVName :: (Name -> Name) -> TyVarBndr_ flag -> TyVarBndr_ flag
+mapTVName fname = mapTV fname id id
+
+-- | Map over the @flag@ of a 'TyVarBndr'.
+mapTVFlag :: (flag -> flag') -> TyVarBndr_ flag -> TyVarBndr_ flag'
+#if MIN_VERSION_template_haskell(2,17,0)
+mapTVFlag = fmap
+#else
+mapTVFlag _ = id
+#endif
+
+-- | Map over the 'Kind' of a 'TyVarBndr'.
+mapTVKind :: (Kind -> Kind) -> TyVarBndr_ flag -> TyVarBndr_ flag
+mapTVKind fkind = mapTV id id fkind
+
+-- | Traverse the components of a 'TyVarBndr'.
+traverseTV :: Applicative f
+           => (Name -> f Name) -> (flag -> f flag') -> (Kind -> f Kind)
+           -> TyVarBndr_ flag -> f (TyVarBndr_ flag')
+#if MIN_VERSION_template_haskell(2,17,0)
+traverseTV fn fflag _fkind (PlainTV n flag) =
+  liftA2 PlainTV (fn n) (fflag flag)
+traverseTV fn fflag fkind (KindedTV n flag kind) =
+  liftA3 KindedTV (fn n) (fflag flag) (fkind kind)
+#else
+traverseTV fn _fflag _fkind (PlainTV n) =
+  PlainTV <$> fn n
+traverseTV fn _fflag fkind (KindedTV n kind) =
+  liftA2 KindedTV (fn n) (fkind kind)
+#endif
+
+-- | Traverse the 'Name' of a 'TyVarBndr'.
+traverseTVName :: Functor f
+               => (Name -> f Name)
+               -> TyVarBndr_ flag -> f (TyVarBndr_ flag)
+#if MIN_VERSION_template_haskell(2,17,0)
+traverseTVName fn (PlainTV n flag) =
+  (\n' -> PlainTV n' flag) <$> fn n
+traverseTVName fn (KindedTV n flag kind) =
+  (\n' -> KindedTV n' flag kind) <$> fn n
+#else
+traverseTVName fn (PlainTV n) =
+  PlainTV <$> fn n
+traverseTVName fn (KindedTV n kind) =
+  (\n' -> KindedTV n' kind) <$> fn n
+#endif
+
+-- | Traverse the @flag@ of a 'TyVarBndr'.
+traverseTVFlag :: Applicative f
+               => (flag -> f flag')
+               -> TyVarBndr_ flag -> f (TyVarBndr_ flag')
+#if MIN_VERSION_template_haskell(2,17,0)
+traverseTVFlag fflag (PlainTV n flag) =
+  PlainTV n <$> fflag flag
+traverseTVFlag fflag (KindedTV n flag kind) =
+  (\flag' -> KindedTV n flag' kind) <$> fflag flag
+#else
+traverseTVFlag _ = pure
+#endif
+
+-- | Traverse the 'Kind' of a 'TyVarBndr'.
+traverseTVKind :: Applicative f
+               => (Kind -> f Kind)
+               -> TyVarBndr_ flag -> f (TyVarBndr_ flag)
+#if MIN_VERSION_template_haskell(2,17,0)
+traverseTVKind _fkind tvb@PlainTV{} =
+  pure tvb
+traverseTVKind fkind (KindedTV n flag kind) =
+  KindedTV n flag <$> fkind kind
+#else
+traverseTVKind _fkind tvb@PlainTV{} =
+  pure tvb
+traverseTVKind fkind (KindedTV n kind) =
+  KindedTV n <$> fkind kind
+#endif
+
+-- | Map over the components of a 'TyVarBndr' in a monadic fashion.
+--
+-- This is the same as 'traverseTV', but with a 'Monad' constraint. This is
+-- mainly useful for use with old versions of @base@ where 'Applicative' was
+-- not a superclass of 'Monad'.
+mapMTV :: Monad m
+       => (Name -> m Name) -> (flag -> m flag') -> (Kind -> m Kind)
+       -> TyVarBndr_ flag -> m (TyVarBndr_ flag')
+#if MIN_VERSION_template_haskell(2,17,0)
+mapMTV fn fflag _fkind (PlainTV n flag) =
+  liftM2 PlainTV (fn n) (fflag flag)
+mapMTV fn fflag fkind (KindedTV n flag kind) =
+  liftM3 KindedTV (fn n) (fflag flag) (fkind kind)
+#else
+mapMTV fn _fflag _fkind (PlainTV n) =
+  liftM PlainTV (fn n)
+mapMTV fn _fflag fkind (KindedTV n kind) =
+  liftM2 KindedTV (fn n) (fkind kind)
+#endif
+
+-- | Map over the 'Name' of a 'TyVarBndr' in a monadic fashion.
+--
+-- This is the same as 'traverseTVName', but with a 'Monad' constraint. This is
+-- mainly useful for use with old versions of @base@ where 'Applicative' was
+-- not a superclass of 'Monad'.
+mapMTVName :: Monad m
+           => (Name -> m Name)
+           -> TyVarBndr_ flag -> m (TyVarBndr_ flag)
+#if MIN_VERSION_template_haskell(2,17,0)
+mapMTVName fn (PlainTV n flag) =
+  liftM (\n' -> PlainTV n' flag) (fn n)
+mapMTVName fn (KindedTV n flag kind) =
+  liftM (\n' -> KindedTV n' flag kind) (fn n)
+#else
+mapMTVName fn (PlainTV n) =
+  liftM PlainTV (fn n)
+mapMTVName fn (KindedTV n kind) =
+  liftM (\n' -> KindedTV n' kind) (fn n)
+#endif
+
+-- | Map over the @flag@ of a 'TyVarBndr' in a monadic fashion.
+--
+-- This is the same as 'traverseTVFlag', but with a 'Monad' constraint. This is
+-- mainly useful for use with old versions of @base@ where 'Applicative' was
+-- not a superclass of 'Monad'.
+mapMTVFlag :: Monad m
+           => (flag -> m flag')
+           -> TyVarBndr_ flag -> m (TyVarBndr_ flag')
+#if MIN_VERSION_template_haskell(2,17,0)
+mapMTVFlag fflag (PlainTV n flag) =
+  liftM (PlainTV n) (fflag flag)
+mapMTVFlag fflag (KindedTV n flag kind) =
+  liftM (\flag' -> KindedTV n flag' kind) (fflag flag)
+#else
+mapMTVFlag _ = return
+#endif
+
+-- | Map over the 'Kind' of a 'TyVarBndr' in a monadic fashion.
+--
+-- This is the same as 'traverseTVKind', but with a 'Monad' constraint. This is
+-- mainly useful for use with old versions of @base@ where 'Applicative' was
+-- not a superclass of 'Monad'.
+mapMTVKind :: Monad m
+           => (Kind -> m Kind)
+           -> TyVarBndr_ flag -> m (TyVarBndr_ flag)
+#if MIN_VERSION_template_haskell(2,17,0)
+mapMTVKind _fkind tvb@PlainTV{} =
+  return tvb
+mapMTVKind fkind (KindedTV n flag kind) =
+  liftM (KindedTV n flag) (fkind kind)
+#else
+mapMTVKind _fkind tvb@PlainTV{} =
+  return tvb
+mapMTVKind fkind (KindedTV n kind) =
+  liftM (KindedTV n) (fkind kind)
+#endif
+
+-- | Set the flag in a list of 'TyVarBndr's. This is often useful in contexts
+-- where one needs to re-use a list of 'TyVarBndr's from one flag setting to
+-- another flag setting. For example, in order to re-use the 'TyVarBndr's bound
+-- by a 'DataD' in a 'ForallT', one can do the following:
+--
+-- @
+-- case x of
+--   'DataD' _ _ tvbs _ _ _ ->
+--     'ForallT' ('changeTVFlags' 'SpecifiedSpec' tvbs) ...
+-- @
+changeTVFlags :: newFlag -> [TyVarBndr_ oldFlag] -> [TyVarBndr_ newFlag]
+#if MIN_VERSION_template_haskell(2,17,0)
+changeTVFlags newFlag = map (newFlag <$)
+#else
+changeTVFlags _ = id
+#endif
+
+-- | Extract the type variable name from a 'TyVarBndr', ignoring the
+-- kind signature if one exists.
+tvName :: TyVarBndr_ flag -> Name
+tvName = elimTV id (\n _ -> n)
+
+-- | Extract the kind from a 'TyVarBndr'. Assumes 'PlainTV' has kind @*@.
+tvKind :: TyVarBndr_ flag -> Kind
+tvKind = elimTV (\_ -> starK) (\_ k -> k)

--- a/test/Harness.hs
+++ b/test/Harness.hs
@@ -27,6 +27,7 @@ import           Data.Map (Map)
 import           Data.Maybe
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Datatype
+import           Language.Haskell.TH.Datatype.TyVarBndr
 import           Language.Haskell.TH.Lib (starK)
 
 validateDI :: DatatypeInfo -> DatatypeInfo -> ExpQ
@@ -110,12 +111,10 @@ equateCI con1 con2 =
         RecordConstructor fields -> RecordConstructor $ map (mkName . nameBase) fields
 
 -- Substitutes both type variable names and kinds.
-substIntoTyVarBndrs :: Map Name Type -> [TyVarBndr] -> [TyVarBndr]
+substIntoTyVarBndrs :: Map Name Type -> [TyVarBndr_ flag] -> [TyVarBndr_ flag]
 substIntoTyVarBndrs subst = map go
   where
-    go (PlainTV n)    = PlainTV $ substName subst n
-    go (KindedTV n k) = KindedTV (substName subst n)
-                                 (applySubstitution subst k)
+    go = mapTV (substName subst) id (applySubstitution subst)
 
     substName :: Map Name Type -> Name -> Name
     substName subst n = fromMaybe n $ do
@@ -124,11 +123,8 @@ substIntoTyVarBndrs subst = map go
         VarT n' -> Just n'
         _       -> Nothing
 
-bndrParams :: [TyVarBndr] -> [Type]
-bndrParams = map $ \bndr ->
-  case bndr of
-    KindedTV t k -> SigT (VarT t) k
-    PlainTV  t   -> VarT t
+bndrParams :: [TyVarBndr_ flag] -> [Type]
+bndrParams = map $ elimTV VarT (\n k -> SigT (VarT n) k)
 
 equateStrictness :: FieldStrictness -> FieldStrictness -> Either String ()
 equateStrictness fs1 fs2 =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -40,6 +40,7 @@ import           Data.Type.Equality ((:~:)(..))
 
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Datatype
+import           Language.Haskell.TH.Datatype.TyVarBndr
 import           Language.Haskell.TH.Lib (starK)
 
 import           Harness
@@ -109,7 +110,7 @@ adt1Test =
   $(do info <- reifyDatatype ''Adt1
 
        let names            = map mkName ["a","b"]
-           [aTvb,bTvb]      = map (\v -> KindedTV v starK) names
+           [aTvb,bTvb]      = map (\v -> kindedTV v starK) names
            vars@[aVar,bVar] = map (VarT . mkName) ["a","b"]
            [aSig,bSig]      = map (\v -> SigT v starK) vars
 
@@ -150,7 +151,7 @@ gadt1Test =
          DatatypeInfo
            { datatypeName = ''Gadt1
            , datatypeContext = []
-           , datatypeVars = [KindedTV a starK]
+           , datatypeVars = [kindedTV a starK]
            , datatypeInstTypes = [SigT aVar starK]
            , datatypeVariant = Datatype
            , datatypeCons =
@@ -197,7 +198,7 @@ gadtrec1Test =
          DatatypeInfo
            { datatypeName      = ''Gadtrec1
            , datatypeContext   = []
-           , datatypeVars      = [KindedTV a starK]
+           , datatypeVars      = [kindedTV a starK]
            , datatypeInstTypes = [SigT (VarT a) starK]
            , datatypeVariant   = Datatype
            , datatypeCons      =
@@ -210,7 +211,7 @@ equalTest =
   $(do info <- reifyDatatype ''Equal
 
        let names                 = map mkName ["a","b","c"]
-           [aTvb,bTvb,cTvb]      = map (\v -> KindedTV v starK) names
+           [aTvb,bTvb,cTvb]      = map (\v -> kindedTV v starK) names
            vars@[aVar,bVar,cVar] = map VarT names
            [aSig,bSig,cSig]      = map (\v -> SigT v starK) vars
 
@@ -256,7 +257,7 @@ showableTest =
            , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'Showable
-                   , constructorVars       = [KindedTV a starK]
+                   , constructorVars       = [kindedTV a starK]
                    , constructorContext    = [classPred ''Show [VarT a]]
                    , constructorFields     = [VarT a]
                    , constructorStrictness = [notStrictAnnot]
@@ -291,7 +292,7 @@ gadt2Test :: IO ()
 gadt2Test =
   $(do info <- reifyDatatype ''Gadt2
        let names            = map mkName ["a","b"]
-           [aTvb,bTvb]      = map (\v -> KindedTV v starK) names
+           [aTvb,bTvb]      = map (\v -> kindedTV v starK) names
            vars@[aVar,bVar] = map VarT names
            [aSig,bSig]      = map (\v -> SigT v starK) vars
            x                = mkName "x"
@@ -316,7 +317,7 @@ gadt2Test =
                , con { constructorName = 'Gadt2c2
                      , constructorContext = [equalPred aVar (AppT ListT bVar)] }
                , con { constructorName = 'Gadt2c3
-                     , constructorVars = [KindedTV x starK]
+                     , constructorVars = [kindedTV x starK]
                      , constructorContext =
                          [equalPred aVar (AppT ListT (VarT x))
                          ,equalPred bVar (AppT ListT (VarT x))] } ]
@@ -331,7 +332,7 @@ voidstosTest =
          DatatypeInfo
            { datatypeName      = ''VoidStoS
            , datatypeContext   = []
-           , datatypeVars      = [KindedTV g (arrowKCompat starK starK)]
+           , datatypeVars      = [kindedTV g (arrowKCompat starK starK)]
            , datatypeInstTypes = [SigT (VarT g) (arrowKCompat starK starK)]
            , datatypeVariant   = Datatype
            , datatypeCons      = []
@@ -425,7 +426,7 @@ t58Test =
            , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = mkName "MkFoo"
-                   , constructorVars       = [KindedTV a starK]
+                   , constructorVars       = [kindedTV a starK]
                    , constructorContext    = []
                    , constructorFields     = [VarT a]
                    , constructorStrictness = [notStrictAnnot]
@@ -443,7 +444,7 @@ dataFamilyTest =
          DatatypeInfo
            { datatypeName      = ''DF
            , datatypeContext   = []
-           , datatypeVars      = [KindedTV a starK]
+           , datatypeVars      = [kindedTV a starK]
            , datatypeInstTypes = [AppT (ConT ''Maybe) (VarT a)]
            , datatypeVariant   = DataInstance
            , datatypeCons      =
@@ -466,7 +467,7 @@ ghc78bugTest =
          DatatypeInfo
            { datatypeName      = ''DF1
            , datatypeContext   = []
-           , datatypeVars      = [KindedTV c starK]
+           , datatypeVars      = [kindedTV c starK]
            , datatypeInstTypes = [SigT cVar starK]
            , datatypeVariant   = DataInstance
            , datatypeCons      =
@@ -490,7 +491,7 @@ quotedTest =
          DatatypeInfo
            { datatypeName      = mkName "Quoted"
            , datatypeContext   = []
-           , datatypeVars      = [KindedTV a starK]
+           , datatypeVars      = [kindedTV a starK]
            , datatypeInstTypes = [SigT aVar starK]
            , datatypeVariant   = DataInstance
            , datatypeCons      =
@@ -515,9 +516,9 @@ polyTest =
            , datatypeContext   = []
            , datatypeVars      = [
 #if __GLASGOW_HASKELL__ >= 800
-                                 KindedTV k starK,
+                                 kindedTV k starK,
 #endif
-                                 KindedTV a kVar ]
+                                 kindedTV a kVar ]
            , datatypeInstTypes = [SigT (VarT a) kVar]
            , datatypeVariant   = DataInstance
            , datatypeCons      =
@@ -535,7 +536,7 @@ gadtFamTest :: IO ()
 gadtFamTest =
   $(do info <- reifyDatatype 'MkGadtFam1
        let names@[c,d,e,q]       = map mkName ["c","d","e","q"]
-           [cTvb,dTvb,eTvb,qTvb] = map (\v -> KindedTV v starK) names
+           [cTvb,dTvb,eTvb,qTvb] = map (\v -> kindedTV v starK) names
            [cTy,dTy,eTy,qTy]     = map VarT names
            [cSig,dSig]           = map (\v -> SigT v starK) [cTy,dTy]
        validateDI info
@@ -555,7 +556,7 @@ gadtFamTest =
                    , constructorVariant    = NormalConstructor }
                , ConstructorInfo
                    { constructorName       = '(:&&:)
-                   , constructorVars       = [KindedTV e starK]
+                   , constructorVars       = [kindedTV e starK]
                    , constructorContext    = [equalPred cTy (AppT ListT eTy)]
                    , constructorFields     = [eTy,dTy]
                    , constructorStrictness = [notStrictAnnot, notStrictAnnot]
@@ -581,7 +582,7 @@ gadtFamTest =
                    , constructorVariant    = NormalConstructor }
                , ConstructorInfo
                    { constructorName       = 'MkGadtFam5
-                   , constructorVars       = [KindedTV q starK]
+                   , constructorVars       = [kindedTV q starK]
                    , constructorContext    = [ equalPred cTy (ConT ''Bool)
                                              , equalPred dTy (ConT ''Bool)
                                              , equalPred qTy (ConT ''Char)
@@ -619,7 +620,7 @@ famLocalDecTest2 =
   $(do [dec] <- [d| data instance FamLocalDec2 Int (a, b) a = FamLocalDec2Int { fm0 :: (b, a), fm1 :: Int } |]
        info <- normalizeDec dec
        let names            = map mkName ["a", "b"]
-           [aTvb,bTvb]      = map (\v -> KindedTV v starK) names
+           [aTvb,bTvb]      = map (\v -> kindedTV v starK) names
            vars@[aVar,bVar] = map (VarT . mkName) ["a", "b"]
            [aSig,bSig]      = map (\v -> SigT v starK) vars
        validateDI info
@@ -658,7 +659,7 @@ t73Test :: IO ()
 t73Test =
   $(do info <- reifyDatatype 'MkT73
        let b    = mkName "b"
-           bTvb = KindedTV b starK
+           bTvb = kindedTV b starK
            bVar = VarT b
        validateDI info
          DatatypeInfo
@@ -706,7 +707,7 @@ reifyDatatypeWithConNameTest =
          DatatypeInfo
           { datatypeContext   = []
           , datatypeName      = ''Maybe
-          , datatypeVars      = [KindedTV a starK]
+          , datatypeVars      = [kindedTV a starK]
           , datatypeInstTypes = [SigT (VarT a) starK]
           , datatypeVariant   = Datatype
           , datatypeCons      =
@@ -742,9 +743,9 @@ importedEqualityTest =
            , datatypeName      = ''(:~:)
            , datatypeVars      = [
 #if __GLASGOW_HASKELL__ >= 800
-                                 KindedTV k starK,
+                                 kindedTV k starK,
 #endif
-                                 KindedTV a kKind, KindedTV b kKind]
+                                 kindedTV a kKind, kindedTV b kKind]
            , datatypeInstTypes = [SigT aVar kKind, SigT bVar kKind]
            , datatypeVariant   = Datatype
            , datatypeCons      =
@@ -765,7 +766,7 @@ kindSubstTest =
   $(do k1 <- newName "k1"
        k2 <- newName "k2"
        a  <- newName "a"
-       let ty = ForallT [KindedTV a (VarT k1)] [] (VarT a)
+       let ty = ForallT [kindedTVSpecified a (VarT k1)] [] (VarT a)
            substTy = applySubstitution (Map.singleton k1 (VarT k2)) ty
 
            checkFreeVars :: Type -> [Name] -> Q ()
@@ -785,9 +786,9 @@ t59Test =
                         -- Proxy (a :: k)
            expected = ForallT
 #if __GLASGOW_HASKELL__ >= 800
-                        [PlainTV k, KindedTV a (VarT k)]
+                        [plainTVSpecified k, kindedTVSpecified a (VarT k)]
 #else
-                        [KindedTV a (VarT k)]
+                        [kindedTVSpecified a (VarT k)]
 #endif
                         [] proxyAK
            actual = quantifyType proxyAK
@@ -814,10 +815,10 @@ t61Test =
        test (SigT (idAppT $ ConT ''Int) (idAppT StarT))
             (SigT (ConT ''Int) StarT)
 #if MIN_VERSION_template_haskell(2,10,0)
-       test (ForallT [KindedTV a (idAppT StarT)]
+       test (ForallT [kindedTVSpecified a (idAppT StarT)]
                      [idAppT (ConT ''Show `AppT` VarT a)]
                      (idAppT $ VarT a))
-            (ForallT [KindedTV a StarT]
+            (ForallT [kindedTVSpecified a StarT]
                      [ConT ''Show `AppT` VarT a]
                      (VarT a))
 #endif
@@ -840,8 +841,8 @@ t66Test =
          DatatypeInfo
            { datatypeName      = mkName "Foo"
            , datatypeContext   = []
-           , datatypeVars      = [ KindedTV a starK ,KindedTV b starK
-                                 , KindedTV f fKind, KindedTV x starK ]
+           , datatypeVars      = [ kindedTV a starK, kindedTV b starK
+                                 , kindedTV f fKind, kindedTV x starK ]
            , datatypeInstTypes = [ SigT (VarT a) starK, SigT (VarT b) starK
                                  , SigT (VarT f) fKind, SigT (VarT x) starK ]
            , datatypeVariant   = Datatype
@@ -860,7 +861,10 @@ t80Test :: IO ()
 t80Test = do
   let [k,a,b] = map mkName ["k","a","b"]
       -- forall k (a :: k) (b :: k). ()
-      t = ForallT [PlainTV k, KindedTV a (VarT k), KindedTV b (VarT k)] [] (ConT ''())
+      t = ForallT [ plainTVSpecified k
+                  , kindedTVSpecified a (VarT k)
+                  , kindedTVSpecified b (VarT k)
+                  ] [] (ConT ''())
 
       expected, actual :: [Name]
       expected = []
@@ -878,9 +882,9 @@ t80Test = do
 t79Test :: IO ()
 t79Test =
   $(do let [a,b,c]  = map mkName ["a","b","c"]
-           t        = ForallT [KindedTV a (UInfixT (VarT b) ''(:+:) (VarT c))] []
+           t        = ForallT [kindedTVSpecified a (UInfixT (VarT b) ''(:+:) (VarT c))] []
                               (ConT ''())
-           expected = ForallT [KindedTV a (ConT ''(:+:) `AppT` VarT b `AppT` VarT c)] []
+           expected = ForallT [kindedTVSpecified a (ConT ''(:+:) `AppT` VarT b `AppT` VarT c)] []
                               (ConT ''())
        actual <- resolveInfixT t
        unless (expected == actual) $
@@ -900,8 +904,8 @@ t37Test =
            [kVar,aVar] = map VarT names
            kSig        = SigT kVar starK
            aSig        = SigT aVar kVar
-           kTvb        = KindedTV k starK
-           aTvb        = KindedTV a kVar
+           kTvb        = kindedTV k starK
+           aTvb        = kindedTV a kVar
        validateDI infoA
          DatatypeInfo
            { datatypeContext   = []
@@ -965,13 +969,13 @@ polyKindedExTyvarTest =
          DatatypeInfo
            { datatypeContext   = []
            , datatypeName      = ''T48
-           , datatypeVars      = [KindedTV a starK]
+           , datatypeVars      = [kindedTV a starK]
            , datatypeInstTypes = [SigT aVar starK]
            , datatypeVariant   = Datatype
            , datatypeCons      =
                [ ConstructorInfo
                    { constructorName       = 'MkT48
-                   , constructorVars       = [KindedTV x aVar]
+                   , constructorVars       = [kindedTV x aVar]
                    , constructorContext    = []
                    , constructorFields     = [ConT ''Prox `AppT` VarT x]
                    , constructorStrictness = [notStrictAnnot]
@@ -982,13 +986,13 @@ polyKindedExTyvarTest =
        -- unfortunately does not check if the uses of `a` in datatypeVars and
        -- constructorVars are the same. We perform this check explicitly here.
        case info of
-         DatatypeInfo { datatypeVars = [KindedTV a1 starK]
+         DatatypeInfo { datatypeVars = [v1]
                       , datatypeCons =
-                          [ ConstructorInfo
-                              { constructorVars = [KindedTV _ (VarT a2)] } ] } ->
-           unless (a1 == a2) $
-             fail $ "Two occurrences of the same variable have different names: "
-                 ++ show [a1, a2]
+                          [ConstructorInfo { constructorVars = [v2] }] }
+           |  a1 <- tvName v1, starK == tvKind v1, VarT a2 <- tvKind v2
+           -> unless (a1 == a2) $
+                fail $ "Two occurrences of the same variable have different names: "
+                    ++ show [a1, a2]
        [| return () |]
    )
 
@@ -1036,8 +1040,8 @@ t63Test =
        t <- newName "T"
        let tauType = ArrowT `AppT` VarT a `AppT` (ArrowT `AppT` VarT b
                        `AppT` (ConT t `AppT` VarT a))
-           sigmaType = ForallT [PlainTV b] [] tauType
-           expected = ForallT [PlainTV a, PlainTV b] [] tauType
+           sigmaType = ForallT [plainTVSpecified b] [] tauType
+           expected = ForallT [plainTVSpecified a, plainTVSpecified b] [] tauType
            actual   = quantifyType sigmaType
        unless (expected == actual) $
          fail $ "quantifyType does not collapse consecutive foralls: "
@@ -1051,7 +1055,7 @@ t70Test =
   $(do a <- newName "a"
        b <- newName "b"
        let [aVar, bVar] = map VarT    [a, b]
-           [aTvb, bTvb] = map PlainTV [a, b]
+           [aTvb, bTvb] = map plainTV [a, b]
        let fvsABExpected = [aTvb, bTvb]
            fvsABActual   = freeVariablesWellScoped [aVar, bVar]
 

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -31,6 +31,7 @@ import GHC.Exts (Constraint)
 
 import Language.Haskell.TH hiding (Type)
 import Language.Haskell.TH.Datatype
+import Language.Haskell.TH.Datatype.TyVarBndr
 import Language.Haskell.TH.Lib (starK)
 
 #if __GLASGOW_HASKELL__ >= 800
@@ -171,7 +172,7 @@ gadtRecVanillaCI =
   where
     a             = VarT (mkName "a")
     names@[v1,v2] = map mkName ["v1","v2"]
-    [v1K,v2K]     = map (\n -> KindedTV n starK) names
+    [v1K,v2K]     = map (\n -> kindedTV n starK) names
 
 #if MIN_VERSION_template_haskell(2,7,0)
 gadtRecFamCI :: ConstructorInfo

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -1,5 +1,5 @@
 name:                th-abstraction
-version:             0.3.2.0
+version:             0.4.0.0
 synopsis:            Nicer interface for reified information about data types
 description:         This package normalizes variations in the interface for
                      inspecting datatype information via Template Haskell
@@ -25,10 +25,11 @@ source-repository head
 
 library
   exposed-modules:     Language.Haskell.TH.Datatype
+                       Language.Haskell.TH.Datatype.TyVarBndr
   other-modules:       Language.Haskell.TH.Datatype.Internal
   build-depends:       base             >=4.3   && <5,
                        ghc-prim,
-                       template-haskell >=2.5   && <2.17,
+                       template-haskell >=2.5   && <2.18,
                        containers       >=0.4   && <0.7
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This patch adapts `th-abstraction` to `template-haskell-2.17.0.0`, which adds a `flag` type parameter to `TyVarBndr`. This makes it especially difficult to support pre-2.17.0.0 versions of `template-haskell` without obnoxious amounts of CPP, so to make things slightly more tolerable, this patch also introduces a new `Language.Haskell.TH.Datatype.TyVarBndr` module. The purpose of this module is to define various type synonyms and utility functions that make it possible to write CPP-free code involving `TyVarBndr`s.

Fixes #81. Fixes #82.