### PR TITLE
Explicitly mark modules as Safe or Trustworthy

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for th-abstraction
 
+## 0.4.2.0 -- 202y-mm-dd
+* Explicitly mark modules as Safe (or Trustworthy for GHC versions prior to 8.4).
+
 ## 0.4.1.0 -- 2020-12-09
 * Fix a bug in which `normalizeDec` would give incorrect kind annotations to
   type variables in quoted `Dec`s. `normalizeDec` now leaves the kinds of

--- a/src/Language/Haskell/TH/Datatype.hs
+++ b/src/Language/Haskell/TH/Datatype.hs
@@ -5,6 +5,12 @@
 {-# Language DeriveGeneric #-}
 #endif
 
+#if MIN_VERSION_template_haskell(2,12,0)
+{-# Language Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# Language Trustworthy #-}
+#endif
+
 {-|
 Module      : Language.Haskell.TH.Datatype
 Description : Backwards-compatible interface to reified information about datatypes.

--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -1,5 +1,11 @@
 {-# LANGUAGE CPP #-}
 
+#if MIN_VERSION_template_haskell(2,12,0)
+{-# Language Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# Language Trustworthy #-}
+#endif
+
 {-|
 Module      : Language.Haskell.TH.Datatype.Internal
 Description : Backwards-compatible interface to reified information about datatypes.

--- a/src/Language/Haskell/TH/Datatype/TyVarBndr.hs
+++ b/src/Language/Haskell/TH/Datatype/TyVarBndr.hs
@@ -5,6 +5,12 @@
 {-# Language DeriveGeneric #-}
 #endif
 
+#if MIN_VERSION_template_haskell(2,12,0)
+{-# Language Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# Language Trustworthy #-}
+#endif
+
 {-|
 Module      : Language.Haskell.TH.Datatype.TyVarBndr
 Description : Backwards-compatible type variable binders

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -1,5 +1,5 @@
 name:                th-abstraction
-version:             0.4.1.0
+version:             0.4.2.0
 synopsis:            Nicer interface for reified information about data types
 description:         This package normalizes variations in the interface for
                      inspecting datatype information via Template Haskell
@@ -33,6 +33,11 @@ library
                        containers       >=0.4   && <0.7
   hs-source-dirs:      src
   default-language:    Haskell2010
+
+  if impl(ghc >= 9.0)
+    -- these flags may abort compilation with GHC-8.10
+    -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3295
+    ghc-options: -Winferred-safe-imports -Wmissing-safe-haskell-mode
 
 test-suite unit-tests
   other-modules:       Harness


### PR DESCRIPTION
I made a minor version bump, as here we actually have a small API change.
For older GHCs, modules are not Unsafe, but Trustworthy now.
So if someone want to be precise and write CPP-conditionals,
it is possible.

(For reference tagged-0.8.6.1 is on the edge, there visibly little
changed, though there Data.Proxy.TH module went through similar
transition).

This PR is part of https://github.com/ekmett/lens/issues/959 effort