### PR TITLE
Support `PromotedInfixT` and `PromotedUInfixT`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for th-abstraction
 
+## next -- ????.??.??
+* Support free variable substitution and infix resolution for
+  `PromotedInfixT` and `PromotedUInfixT` on `template-haskell-2.19.0.0` or
+  later.
+
 ## 0.4.3.0 -- 2021.08.30
 * Make `applySubstitution` avoid capturing type variable binders when
   substituting into `forall`s.

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -71,6 +71,8 @@ data StrictDemo = StrictDemo Int !Int {-# UNPACK #-} !Int
 
 type (:+:) = Either
 
+data MyPair a b = a :^: b
+
 -- Data families
 data family T43Fam
 

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -29,7 +29,7 @@ library
   other-modules:       Language.Haskell.TH.Datatype.Internal
   build-depends:       base             >=4.3   && <5,
                        ghc-prim,
-                       template-haskell >=2.5   && <2.19,
+                       template-haskell >=2.5   && <2.20,
                        containers       >=0.4   && <0.7
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
`template-haskell-2.19.0.0` adds `PromotedInfixT` and `PromotedUInfixT`, which are promoted counterparts to `InfixT` and `UInfixT`. (See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7134.) This adds support them in `th-abstraction`:

* Permit free variable calculations with `PromotedInfixT` and `PromotedUInfixT`
* Allow resolving type synonyms underneath `PromotedInfixT` and `PromotedUInfixT`
* Support `PromotedInfixT` and `PromotedUInfixT` in `resolveInfixT`