### PR TITLE
`repairVarKindsWith`: Include binders from explicit return kinds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for th-abstraction
 
+## next -- ????.??.??
+* Fix a bug in which data family declarations with interesting return kinds
+  (e.g., `data family F :: Type -> Type`) would be reified incorrectly when
+  using `reifyDatatype`.
+
 ## 0.4.4.0 -- 2022.07.23
 * Support free variable substitution and infix resolution for
   `PromotedInfixT` and `PromotedUInfixT` on `template-haskell-2.19.0.0` or

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -74,6 +74,7 @@ main =
      recordFamTest
      t46Test
      t73Test
+     t95Test
 #endif
      fixityLookupTest
 #if __GLASGOW_HASKELL__ >= 704
@@ -678,6 +679,30 @@ t73Test =
                    , constructorVars       = []
                    , constructorContext    = []
                    , constructorFields     = [bVar]
+                   , constructorStrictness = [notStrictAnnot]
+                   , constructorVariant    = NormalConstructor }]
+           }
+   )
+
+t95Test :: IO ()
+t95Test =
+  $(do info <- reifyDatatype 'MkT95
+       let a    = mkName "a"
+           aTvb = kindedTV a starK
+           aVar = VarT a
+       validateDI info
+         DatatypeInfo
+           { datatypeName      = ''T95
+           , datatypeContext   = []
+           , datatypeVars      = [aTvb]
+           , datatypeInstTypes = [AppT ListT aVar]
+           , datatypeVariant   = DataInstance
+           , datatypeCons      =
+               [ ConstructorInfo
+                   { constructorName       = 'MkT95
+                   , constructorVars       = []
+                   , constructorContext    = []
+                   , constructorFields     = [aVar]
                    , constructorStrictness = [notStrictAnnot]
                    , constructorVariant    = NormalConstructor }]
            }

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -116,6 +116,9 @@ data instance T46 (f (p :: *)) (f p) q = MkT46 q
 
 data family   T73 a   b
 data instance T73 Int b = MkT73 b
+
+data family T95 :: * -> *
+data instance T95 [a] = MkT95 a
 #endif
 
 #if __GLASGOW_HASKELL__ >= 704


### PR DESCRIPTION
Due to an oversight, the implementation of `repairVarKindsWith` could inadvertently truncate the value it returns when its `[TyVarBndr]` argument is less than its `[Type]` argument, which leads to the confusing results seen in #95. This can actually happen in practice when dealing with data family declarations like `data family D :: Type -> Type`, where some of the kinds are declared in the return kind rather than in the type variable binders.

Fortunately, we already have a `mkExtraKindBinders` function just for this very purpose, so fixing this bug is a simple matter of using `mkExtraKindBinders` in `repairVarKindsWith` to ensure that the `TyVarBndr` list is of equal length to the `Type` list.

Fixes #95.