### PR TITLE
Define a `Lift` instance for `Specificity` on pre-9.0 GHCs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for th-abstraction
 
+## next -- ????.??.??
+* Add a `Lift` instance for `th-abstraction`'s compatibility shim for
+  `Specificity` when building with pre-9.0 versions of GHC.
+
 ## 0.4.5.0 -- 2022.09.12
 * Fix a bug in which data family declarations with interesting return kinds
   (e.g., `data family F :: Type -> Type`) would be reified incorrectly when

--- a/src/Language/Haskell/TH/Datatype/TyVarBndr.hs
+++ b/src/Language/Haskell/TH/Datatype/TyVarBndr.hs
@@ -11,6 +11,11 @@
 {-# Language Trustworthy #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+#define HAS_TH_LIFT
+{-# Language DeriveLift #-}
+#endif
+
 {-|
 Module      : Language.Haskell.TH.Datatype.TyVarBndr
 Description : Backwards-compatible type variable binders
@@ -102,6 +107,9 @@ data Specificity
   deriving (Show, Eq, Ord, Typeable, Data
 #ifdef HAS_GENERICS
            ,Generic
+#endif
+#ifdef HAS_TH_LIFT
+           ,Lift
 #endif
            )
 


### PR DESCRIPTION
Fixes #97.