### PR TITLE
Only enable `TypeInType` on pre-8.6 GHCs

### DIFF
--- a/test/Types.hs
+++ b/test/Types.hs
@@ -9,7 +9,10 @@
 #endif
 
 #if __GLASGOW_HASKELL__ >= 800
+{-# Language DataKinds #-}
+# if __GLASGOW_HASKELL__ < 806
 {-# Language TypeInType #-}
+# endif
 #endif
 
 {-|


### PR DESCRIPTION
After GHC 8.6, `TypeInType`'s functionality was made a part of the `DataKinds` and `PolyKinds` extensions. Moreover, GHC 9.6 gives a deprecation warning when using `TypeInType`, so we now have an extra incentive to only enable `TypeInType` where absolutely necessary.