### PR TITLE
Add compatibility shims for `TypeAbstractions` in GHC 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230217
+# version: 0.16.3
 #
-# REGENDATA ("0.15.20230217",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.16.3",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,19 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.0.20230210
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.6.0.20230210
-            setup-method: ghcup
-            allow-failure: true
-          - compiler: ghc-9.4.4
-            compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.6
+          - compiler: ghc-9.4.5
             compilerKind: ghc
-            compilerVersion: 9.2.6
+            compilerVersion: 9.4.5
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.7
+            compilerKind: ghc
+            compilerVersion: 9.2.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -116,20 +116,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -147,20 +145,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -189,18 +187,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -217,8 +203,8 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
@@ -252,9 +238,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(th-abstraction)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,168 @@
 # Revision history for th-abstraction
 
+## 0.6.0.0 -- ????.??.??
+* Support building with `template-haskell-2.21.0.0` (GHC 9.8).
+* Adapt to `TyVarBndr`s for type-level declarations changing their type from
+  `TyVarBndr ()` to `TyVarBndr BndrVis` in `template-haskell`:
+
+  * `Language.Haskell.TH.Datatype.TyVarBndr` now backports `type BndrVis = ()`,
+    as well as `BndrReq` and `BndrInvis` pattern synonyms. These make it
+    possible to write code involving `BndrVis` that is somewhat backwards
+    compatible (but do see the caveats in the Haddocks for `BndrInvis`).
+  * `Language.Haskell.TH.Datatype.TyVarBndr` also backports the following
+    definitions:
+    * The `type TyVarBndrVis = TyVarBndr BndrVis` type synonym.
+    * The `DefaultBndrFlag` class, which can be used to write code that is
+      polymorphic over `TyVarBndr` flags while still allowing the code to return
+      a reasonable default value for the flag.
+    * The `bndrReq` and `bndrInvis` definitions, which behave identically to
+      `BndrReq` and `BndrInvis`.
+  * `Language.Haskell.TH.Datatype.TyVarBndr` now defines the following utility
+    functions, which are not present in `template-haskell`:
+    * `plainTVReq`, `plainTVInvis`, `kindedTVReq`, and `kindedTVInvis`
+      functions, which construct `PlainTV`s and `KindedTV`s with particular
+      `BndrVis` flags.
+    * An `elimTVFlag`, which behaves like `elimTV`, but where the continuation
+      arguments also take a `flag` argument. (Note that the type of this
+      function is slightly different on old versions of `template-haskell`.
+      See the Haddocks for more.)
+    * A `tvFlag` function, which extracts the `flag` from a `TyVarBndr`. (Note
+      that the type of this function is slightly different on old versions of
+      `template-haskell`. See the Haddocks for more.)
+  * The types of the `dataDCompat` and `newtypeDCompat` functions have had
+    their `[TyVarBndrUnit]` arguments changed to `[TyVarBndrVis]`, matching
+    similar changes to `DataD` and `NewtypeD` in `template-haskell`.
+
+  Because `BndrVis` is a synonym for `()` on pre-9.8 versions of GHC, this
+  change is unlikely to break any existing code, provided that you build it
+  with GHC 9.6 or earlier. If you build with GHC 9.8 or later, on the other
+  hand, it is likely that you will need to update your existing code. Here are
+  some possible ways that your code might fail to compile with GHC 9.8, along
+  with some migration strategies:
+
+  * Your code passes a `TyVarBndrUnit` in a place where a `TyVarBndrVis` is now
+    expected in GHC 9.8, such as in the arguments to `dataDCompat`:
+
+    ```hs
+    import "template-haskell" Language.Haskell.TH
+    import "th-abstraction"   Language.Haskell.TH.Datatype (dataDCompat)
+
+    dec :: DecQ
+    dec = dataDCompat (pure []) d [PlainTV a ()] [] []
+      where
+        d = mkName "d"
+        a = mkName "a"
+    ```
+
+    With GHC 9.8, this will fail to compile with:
+
+    ```
+    error: [GHC-83865]
+        • Couldn't match expected type ‘BndrVis’ with actual type ‘()’
+        • In the second argument of ‘PlainTV’, namely ‘()’
+          In the expression: PlainTV a ()
+          In the third argument of ‘dataDCompat’, namely ‘[PlainTV a ()]’
+      |
+      | dec = dataDCompat (pure []) d [PlainTV a ()] [] []
+      |                                          ^^
+    ```
+
+    Some possible ways to migrate this code include:
+
+    * Use the `bndrReq` function or `BndrReq` pattern synonym in place of `()`,
+      making sure to import them from `Language.Haskell.TH.Datatype.TyVarBndr`:
+
+      ```hs
+      ...
+      import "th-abstraction" Language.Haskell.TH.Datatype.TyVarBndr
+
+      dec :: DecQ
+      dec = dataDCompat (pure []) d [PlainTV a bndrReq] [] []
+      -- Or, alternatively:
+      {-
+      dec = dataDCompat (pure []) d [PlainTV a BndrReq] [] []
+      -}
+        where
+          ...
+      ```
+    * Use the `plainTV` function from `Language.Haskell.TH.Datatype.TyVarBndr`,
+      which is now sufficiently polymorphic to work as both a `TyVarBndrUnit`
+      and a `TyVarBndrVis`:
+
+      ```hs
+      ...
+      import Language.Haskell.TH.Datatype.TyVarBndr
+
+      dec :: DecQ
+      dec = dataDCompat (pure []) d [plainTV a] [] []
+        where
+          ...
+      ```
+  * You may have to replace some uses of `TyVarBndrUnit` with `TyVarBndrVis`
+    in your code. For instance, this will no longer typecheck in GHC 9.8 for
+    similar reasons to the previous example:
+
+    ```hs
+    import "template-haskell" Language.Haskell.TH
+    import "th-abstraction"   Language.Haskell.TH.Datatype (dataDCompat)
+
+    dec :: DecQ
+    dec = dataDCompat (pure []) d tvbs [] []
+      where
+        tvbs :: [TyVarBndrUnit]
+        tvbs = [plainTV a]
+
+        d = mkName "d"
+        a = mkName "a"
+    ```
+
+    Here is a version that will typecheck with GHC 9.8 and earlier:
+
+    ```hs
+    ...
+    import "th-abstraction" Language.Haskell.TH.Datatype.TyVarBndr
+
+    dec :: DecQ
+    dec = dataDCompat (pure []) d tvbs [] []
+      where
+        tvbs :: [TyVarBndrVis]
+        tvbs = [plainTV a]
+
+        ...
+    ```
+  * In some cases, the `TyVarBndrUnit`s might come from another place in the
+    code, e.g.,
+
+    ```hs
+    import "template-haskell" Language.Haskell.TH
+    import "th-abstraction"   Language.Haskell.TH.Datatype (dataDCompat)
+
+    dec :: [TyVarBndrUnit] -> DecQ
+    dec tvbs = dataDCompat (pure []) d tvbs [] []
+      where
+        d = mkName "d"
+    ```
+
+    If it is not straightforward to change `dec`'s type to accept
+    `[TyVarBndrVis]` as an argument, another viable option is to use the
+    `changeTVFlags` function:
+
+    ```hs
+    ...
+    import "th-abstraction" Language.Haskell.TH.Datatype.TyVarBndr
+
+    dec :: [TyVarBndrUnit] -> DecQ
+    dec tvbs = dataDCompat (pure []) d tvbs' [] []
+      where
+        tvbs' :: [TyVarBndrVis]
+        tvbs' = changeTVFlags bndrReq tvbs
+
+        ...
+    ```
+
+  This guide, while not comprehensive, should cover most of the common cases one
+  will encounter when migrating their `th-abstraction` code to support GHC 9.8.
+
 ## 0.5.0.0 -- 2023.02.27
 * Support the `TypeData` language extension added in GHC 9.6. The
   `DatatypeVariant` data type now has a separate `TypeData` constructor to

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,6 +13,10 @@
 {-# Language PolyKinds #-}
 #endif
 
+#if MIN_VERSION_template_haskell(2,21,0)
+{-# Language TypeAbstractions #-}
+#endif
+
 {-|
 Module      : Main
 Description : Test cases for the th-abstraction package
@@ -112,6 +116,9 @@ main =
      captureAvoidanceTest
 #if MIN_VERSION_template_haskell(2,20,0)
      t100Test
+#endif
+#if MIN_VERSION_template_haskell(2,21,0)
+     t103Test
 #endif
 
 adt1Test :: IO ()
@@ -1177,5 +1184,24 @@ t100Test =
 
        mkT100Info <- reifyDatatype ''MkT100
        validateDI mkT100Info expectedInfo
+   )
+#endif
+
+#if MIN_VERSION_template_haskell(2,21,0)
+t103Test :: IO ()
+t103Test =
+  $(do [dec] <- [d| data T102 @k (a :: k) |]
+       info <- normalizeDec dec
+       let k = mkName "k"
+           a = mkName "a"
+       validateDI info
+         DatatypeInfo
+           { datatypeName      = mkName "T102"
+           , datatypeContext   = []
+           , datatypeVars      = [plainTV k, kindedTV a (VarT k)]
+           , datatypeInstTypes = [SigT (VarT a) (VarT k)]
+           , datatypeVariant   = Datatype
+           , datatypeCons      = []
+           }
    )
 #endif

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -17,7 +17,7 @@ category:            Development
 build-type:          Simple
 extra-source-files:  ChangeLog.md README.md
 cabal-version:       >=1.10
-tested-with:         GHC==9.6.1, GHC==9.4.4, GHC==9.2.6, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
+tested-with:         GHC==9.6.2, GHC==9.4.5, GHC==9.2.7, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
 
 source-repository head
   type: git

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -1,5 +1,5 @@
 name:                th-abstraction
-version:             0.5.0.0
+version:             0.6.0.0
 synopsis:            Nicer interface for reified information about data types
 description:         This package normalizes variations in the interface for
                      inspecting datatype information via Template Haskell
@@ -29,7 +29,7 @@ library
   other-modules:       Language.Haskell.TH.Datatype.Internal
   build-depends:       base             >=4.3   && <5,
                        ghc-prim,
-                       template-haskell >=2.5   && <2.21,
+                       template-haskell >=2.5   && <2.22,
                        containers       >=0.4   && <0.7
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
GHC 9.8 implements [GHC proposal #425](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0425-decl-invis-binders.rst), which adds support for invisible binders for type-level declarations. This impacts Template Haskell, as various `TyVarBndr`s are now parameterized by a new `BndrVis` type instead of `()`.

As such, `th-abstraction` must be updated accordingly. This patch does so by:

* Backporting `BndrVis` to `Language.Haskell.TH.Datatype.TyVarBndr`, as well as related types and utility functions. With these changes, one can write `BndrVis`-related code that will compile on all GHC versions without CPP.

* Changing `dataDCompat` and `newtypeDCompat` in `Language.Haskell.TH.Datatype` to use `TyVarBndrVis` instead of `TyVarBndrUnit` to make it compile on GHC 9.8, matching similar changes in `DataD` and `NewtypeD` in `template-haskell`. Because `BndrVis` is a synonym for `()` on pre-9.8 versions of GHC, this change is unlikely to break any existing code, but do be aware of this change if you write code that needs to support GHC 9.8 or later.

See the `th-abstraction` changelog for the full details.

Fixes https://github.com/glguy/th-abstraction/issues/103.