### PR TITLE
Compute `datatypeInstVars` correctly when return kind contains `forall`s

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,8 @@
 # Revision history for th-abstraction
 
 ## next -- ????.??.??
-* Fix a bug in which `normalizeDec` would return incorrect results for GADTs
-  that use visible dependent quantification in their return kind.
+* Fix a couple of bugs in which `normalizeDec` would return incorrect results
+  for GADTs that use `forall`s in their return kind.
 
 ## 0.6.0.0 -- 2023.07.31
 * Support building with `template-haskell-2.21.0.0` (GHC 9.8).


### PR DESCRIPTION
Previously, we were simply calling `freeVariablesWellScoped` on the explicit return kind in a data type, but this gave incorrect results for data types like this one:

```hs
data T :: forall k. k -> Type where ...
```

Here, we want `datatypeInstVars` to be `[k, (a :: k)]` (where `a` is fresh), but we were instead getting `[(a :: k)]`. The problem was that `k` doesn't occur free in `forall k. k -> Type`, so `th-abstraction` never realized that `k` should be a part of `datatypeInstVars`.

We now compute `datatypeInstVars` in a more intelligent way by splitting apart the explicit return kind using the new `mkExtraFunArgForalls` function. We then pass the resulting `FunArgs` to `funArgTys` and compute the free variables of the resulting `Type`s. By this point, all `forall`s have been split apart, which ensures that we detect things like the `k` in `forall k. ...`.

Fixes #110.