### PR TITLE
Handle tricky return kinds better

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
 # Revision history for th-abstraction
 
 ## next -- ????.??.??
+* `normalizeCon` now takes a `Kind` argument representing the return kind of
+  the parent data type. (This is sometimes necessary to determine which type
+  variables in the data constructor are universal or existential, depending
+  on if the variables appear in the return kind.)
 * Fix a couple of bugs in which `normalizeDec` would return incorrect results
   for GADTs that use `forall`s in their return kind.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Revision history for th-abstraction
 
-## next -- ????.??.??
+## 0.7.0.0 -- ????.??.??
 * `normalizeCon` now takes a `Kind` argument representing the return kind of
   the parent data type. (This is sometimes necessary to determine which type
   variables in the data constructor are universal or existential, depending

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -49,6 +49,10 @@ import           Data.Kind
 import           Data.Type.Equality ((:~:)(..))
 #endif
 
+#if __GLASGOW_HASKELL__ >= 810
+import           GHC.Exts (Any, RuntimeRep, TYPE)
+#endif
+
 import qualified Language.Haskell.TH as TH (Type)
 import           Language.Haskell.TH hiding (Type)
 import           Language.Haskell.TH.Datatype as Datatype
@@ -129,6 +133,7 @@ main =
      t103Test
 #endif
 #if __GLASGOW_HASKELL__ >= 810
+     t107Test
      t108Test
 #endif
 #if __GLASGOW_HASKELL__ >= 804
@@ -1221,6 +1226,30 @@ t103Test =
 #endif
 
 #if __GLASGOW_HASKELL__ >= 810
+t107Test :: IO ()
+t107Test =
+  $(do info <- reifyDatatype ''T107
+       let r = mkName "r"
+       validateDI info
+         DatatypeInfo
+           { datatypeName      = mkName "T107"
+           , datatypeContext   = []
+           , datatypeVars      = [kindedTV r (ConT ''RuntimeRep)]
+           , datatypeInstTypes = []
+           , datatypeVariant   = Newtype
+           , datatypeCons      =
+               [ ConstructorInfo
+                   { constructorName       = mkName "MkT107"
+                   , constructorVars       = []
+                   , constructorContext    = []
+                   , constructorFields     = [ConT ''Any `SigT` (ConT ''TYPE `AppT` VarT r)]
+                   , constructorStrictness = [notStrictAnnot]
+                   , constructorVariant    = NormalConstructor
+                   }
+               ]
+           }
+   )
+
 t108Test :: IO ()
 t108Test =
   $(do [dec] <- [d| data T108 :: forall k -> k -> Type where

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -15,6 +15,12 @@
 # endif
 #endif
 
+#if __GLASGOW_HASKELL__ >= 810
+{-# Language StandaloneKindSignatures #-}
+{-# Language TypeApplications #-}
+{-# Language UnliftedNewtypes #-}
+#endif
+
 #if MIN_VERSION_template_haskell(2,20,0)
 {-# Language TypeData #-}
 #endif
@@ -43,6 +49,10 @@ import Language.Haskell.TH.Lib (starK)
 
 #if __GLASGOW_HASKELL__ >= 800
 import Data.Kind
+#endif
+
+#if __GLASGOW_HASKELL__ >= 810
+import GHC.Exts (Any, TYPE)
 #endif
 
 type Gadt1Int = Gadt1 Int
@@ -144,9 +154,15 @@ data PredSynT =
 data T37a (k :: Type) :: k -> Type where
   MkT37a :: T37a Bool a
 
+# if __GLASGOW_HASKELL__ >= 810
+type T37b :: k -> Type
+# endif
 data T37b (a :: k) where
   MkT37b :: forall (a :: Bool). T37b a
 
+# if __GLASGOW_HASKELL__ >= 810
+type T37c :: k -> Type
+# endif
 data T37c (a :: k) where
   MkT37c :: T37c Bool
 
@@ -161,6 +177,12 @@ data T75 (k :: Type) where
 
 #if MIN_VERSION_template_haskell(2,20,0)
 type data T100 = MkT100
+#endif
+
+#if __GLASGOW_HASKELL__ >= 810
+type T107 :: TYPE r
+newtype T107 where
+  MkT107 :: forall r. Any @(TYPE r) -> T107 @r
 #endif
 
 -- We must define these here due to Template Haskell staging restrictions

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -1,5 +1,5 @@
 name:                th-abstraction
-version:             0.6.0.0
+version:             0.7.0.0
 synopsis:            Nicer interface for reified information about data types
 description:         This package normalizes variations in the interface for
                      inspecting datatype information via Template Haskell


### PR DESCRIPTION
See the new `Note [Tricky return kinds]` for the full story. The tl;dr version is that we:

1. Make an effort to use `reifyType` to determine return kinds for data types where `reify` isn't enough, and
2. If a GADT constructor's return type is of the form `T :: K`, then we unify the data type's return kind with `K` to better determine which type variables are universal or existential.

Fixes #107.