### PR TITLE
Drop support for pre-8.0 versions of GHC

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.17.20231010
+# version: 0.19.20241202
 #
-# REGENDATA ("0.17.20231010",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.19.20241202",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,24 +23,29 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.1
+          - compiler: ghc-9.10.1
             compilerKind: ghc
-            compilerVersion: 9.8.1
+            compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.3
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.6.3
+            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.7
+          - compiler: ghc-9.6.6
             compilerKind: ghc
-            compilerVersion: 9.4.7
+            compilerVersion: 9.6.6
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.8
+            compilerKind: ghc
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -61,79 +66,53 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.4.2
-            compilerKind: ghc
-            compilerVersion: 7.4.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.2.2
-            compilerKind: ghc
-            compilerVersion: 7.2.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.0.4
-            compilerKind: ghc
-            compilerVersion: 7.0.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -144,30 +123,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -217,7 +178,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -245,7 +206,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(th-abstraction)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(th-abstraction)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -253,7 +214,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -276,8 +237,8 @@ jobs:
         run: |
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: save cache
-        uses: actions/cache/save@v3
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for th-abstraction
 
+## next -- ????.??.??
+* Drop support for pre-8.0 versions of GHC.
+
 ## 0.7.0.0 -- 2024.03.17
 * `DatatypeInfo` now has an additional `datatypeReturnKind` field. Most of the
   time, this will be `StarT`, but this can also be more exotic kinds such as

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,3 @@
-distribution:           bionic
+distribution:           jammy
 no-tests-no-benchmarks: False
 unconstrained:          False

--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -2,7 +2,7 @@
 
 #if MIN_VERSION_template_haskell(2,12,0)
 {-# Language Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
+#else
 {-# Language Trustworthy #-}
 #endif
 
@@ -21,7 +21,7 @@ module Language.Haskell.TH.Datatype.Internal where
 import Language.Haskell.TH.Syntax
 
 eqTypeName :: Name
-#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,13,0))
+#if !(MIN_VERSION_base(4,13,0))
 eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"
 #else
 eqTypeName = mkNameG_tc "ghc-prim" "GHC.Types" "~"

--- a/src/Language/Haskell/TH/Datatype/TyVarBndr.hs
+++ b/src/Language/Haskell/TH/Datatype/TyVarBndr.hs
@@ -1,24 +1,9 @@
-{-# Language CPP, DeriveDataTypeable #-}
-
-#if MIN_VERSION_base(4,4,0)
-#define HAS_GENERICS
-{-# Language DeriveGeneric #-}
-#endif
+{-# Language CPP, DeriveDataTypeable, DeriveGeneric, DeriveLift, PatternSynonyms, ViewPatterns #-}
 
 #if MIN_VERSION_template_haskell(2,12,0)
 {-# Language Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
+#else
 {-# Language Trustworthy #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 708
-{-# Language PatternSynonyms #-}
-{-# Language ViewPatterns #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 800
-#define HAS_TH_LIFT
-{-# Language DeriveLift #-}
 #endif
 
 {-|
@@ -42,12 +27,10 @@ module Language.Haskell.TH.Datatype.TyVarBndr (
   , Specificity(..)
 #if __GLASGOW_HASKELL__ >= 907
   , BndrVis(..)
-#elif __GLASGOW_HASKELL__ >= 708
+#else
   , BndrVis
   , pattern BndrReq
   , pattern BndrInvis
-#else
-  , BndrVis
 #endif
   , DefaultBndrFlag(..)
 
@@ -102,13 +85,10 @@ module Language.Haskell.TH.Datatype.TyVarBndr (
 
 import Control.Applicative
 import Control.Monad
-import Data.Data (Typeable, Data)
+import Data.Data (Data)
+import GHC.Generics (Generic)
 import Language.Haskell.TH.Lib
 import Language.Haskell.TH.Syntax
-
-#ifdef HAS_GENERICS
-import GHC.Generics (Generic)
-#endif
 
 -- | A type synonym for 'TyVarBndr'. This is the recommended way to refer to
 -- 'TyVarBndr's if you wish to achieve backwards compatibility with older
@@ -132,14 +112,7 @@ type TyVarBndrSpec = TyVarBndr
 data Specificity
   = SpecifiedSpec -- ^ @a@. Eligible for visible type application.
   | InferredSpec  -- ^ @{a}@. Not eligible for visible type application.
-  deriving (Show, Eq, Ord, Typeable, Data
-#ifdef HAS_GENERICS
-           ,Generic
-#endif
-#ifdef HAS_TH_LIFT
-           ,Lift
-#endif
-           )
+  deriving (Show, Eq, Ord, Data, Generic, Lift)
 
 inferredSpec :: Specificity
 inferredSpec = InferredSpec
@@ -162,14 +135,11 @@ type BndrVis = ()
 {-# COMPLETE BndrReq, BndrInvis #-}
 #endif
 
-#if __GLASGOW_HASKELL__ >= 708
 -- | Because pre-9.8 GHCs do not support invisible binders in type-level
 -- declarations, we simply make 'BndrReq' a pattern synonym for @()@ as a
 -- compatibility shim for old GHCs. This matches how type-level 'TyVarBndr's
 -- were flagged prior to GHC 9.8.
-#if __GLASGOW_HASKELL__ >= 800
 pattern BndrReq :: BndrVis
-#endif
 pattern BndrReq = ()
 
 -- | Because pre-9.8 GHCs do not support invisible binders in type-level
@@ -199,11 +169,8 @@ pattern BndrReq = ()
 --   'BndrInvis' that would construct an invisible type-level binder on GHC 9.8
 --   or later, but a /visible/ type-level binder on older GHCs! This would be
 --   disastrous, so we prevent the user from doing such a thing.
-#if __GLASGOW_HASKELL__ >= 800
 pattern BndrInvis :: BndrVis
-#endif
 pattern BndrInvis <- ((\() -> True) -> False)
-#endif
 
 bndrReq :: BndrVis
 bndrReq = ()

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -1,18 +1,7 @@
-{-# Language CPP, FlexibleContexts, TypeFamilies, KindSignatures, TemplateHaskell, GADTs, ScopedTypeVariables, TypeOperators #-}
+{-# Language CPP, FlexibleContexts, TypeFamilies, KindSignatures, TemplateHaskell, GADTs, ScopedTypeVariables, TypeOperators, ConstraintKinds, DataKinds, PolyKinds #-}
 
-#if __GLASGOW_HASKELL__ >= 704
-{-# LANGUAGE ConstraintKinds #-}
-#endif
-
-#if MIN_VERSION_template_haskell(2,8,0)
-{-# Language PolyKinds #-}
-#endif
-
-#if __GLASGOW_HASKELL__ >= 800
-{-# Language DataKinds #-}
-# if __GLASGOW_HASKELL__ < 806
+#if __GLASGOW_HASKELL__ < 806
 {-# Language TypeInType #-}
-# endif
 #endif
 
 #if __GLASGOW_HASKELL__ >= 810
@@ -38,18 +27,14 @@ on various versions of GHC.
 -}
 module Types where
 
-#if __GLASGOW_HASKELL__ >= 704
+import Data.Kind
+
 import GHC.Exts (Constraint)
-#endif
 
 import Language.Haskell.TH hiding (Type)
 import Language.Haskell.TH.Datatype
 import Language.Haskell.TH.Datatype.TyVarBndr
 import Language.Haskell.TH.Lib (starK)
-
-#if __GLASGOW_HASKELL__ >= 800
-import Data.Kind
-#endif
 
 #if __GLASGOW_HASKELL__ >= 810
 import GHC.Exts (Any, TYPE)
@@ -95,24 +80,15 @@ data family T43Fam
 
 type Id (a :: *) = a
 
-#if MIN_VERSION_template_haskell(2,7,0)
 data family DF (a :: *)
 data instance DF (Maybe a) = DFMaybe Int [a]
 
-# if MIN_VERSION_template_haskell(2,8,0)
 data family DF1 (a :: k)
-# else
-data family DF1 (a :: *)
-# endif
 data instance DF1 (b :: *) = DF1 b
 
 data family Quoted (a :: *)
 
-# if MIN_VERSION_template_haskell(2,8,0)
 data family Poly (a :: k)
-# else
-data family Poly (a :: *)
-# endif
 data instance Poly a = MkPoly
 
 data family GadtFam (a :: *) (b :: *)
@@ -136,9 +112,7 @@ data instance T73 Int b = MkT73 b
 
 data family T95 :: * -> *
 data instance T95 [a] = MkT95 a
-#endif
 
-#if __GLASGOW_HASKELL__ >= 704
 type Konst (a :: Constraint) (b :: Constraint) = a
 type PredSyn1 a b = Konst (Show a) (Read b)
 type PredSyn2 a b = Konst (PredSyn1 a b) (Show a)
@@ -148,21 +122,19 @@ data PredSynT =
     PredSyn1 Int Int => MkPredSynT1 Int
   | PredSyn2 Int Int => MkPredSynT2 Int
   | PredSyn3 Int     => MkPredSynT3 Int
-#endif
 
-#if __GLASGOW_HASKELL__ >= 800
 data T37a (k :: Type) :: k -> Type where
   MkT37a :: T37a Bool a
 
-# if __GLASGOW_HASKELL__ >= 810
+#if __GLASGOW_HASKELL__ >= 810
 type T37b :: k -> Type
-# endif
+#endif
 data T37b (a :: k) where
   MkT37b :: forall (a :: Bool). T37b a
 
-# if __GLASGOW_HASKELL__ >= 810
+#if __GLASGOW_HASKELL__ >= 810
 type T37c :: k -> Type
-# endif
+#endif
 data T37c (a :: k) where
   MkT37c :: T37c Bool
 
@@ -173,7 +145,6 @@ data T48 :: Type -> Type where
 
 data T75 (k :: Type) where
   MkT75 :: forall k (a :: k). Prox a -> T75 k
-#endif
 
 #if MIN_VERSION_template_haskell(2,20,0)
 type data T100 = MkT100
@@ -212,7 +183,6 @@ gadtRecVanillaCI =
     names@[v1,v2] = map mkName ["v1","v2"]
     [v1K,v2K]     = map (\n -> kindedTV n starK) names
 
-#if MIN_VERSION_template_haskell(2,7,0)
 gadtRecFamCI :: ConstructorInfo
 gadtRecFamCI =
   ConstructorInfo
@@ -226,4 +196,3 @@ gadtRecFamCI =
     , constructorVariant    = RecordConstructor ['famRec1, 'famRec2] }
   where
     [cTy,dTy] = map (VarT . mkName) ["c", "d"]
-#endif

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -17,7 +17,7 @@ category:            Development
 build-type:          Simple
 extra-source-files:  ChangeLog.md README.md
 cabal-version:       >=1.10
-tested-with:         GHC==9.8.1, GHC==9.6.3, GHC==9.4.7, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
+tested-with:         GHC==9.10.1, GHC==9.8.4, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
 
 source-repository head
   type: git
@@ -27,9 +27,9 @@ library
   exposed-modules:     Language.Haskell.TH.Datatype
                        Language.Haskell.TH.Datatype.TyVarBndr
   other-modules:       Language.Haskell.TH.Datatype.Internal
-  build-depends:       base             >=4.3   && <5,
+  build-depends:       base             >=4.9   && <5,
                        ghc-prim,
-                       template-haskell >=2.5   && <2.23,
+                       template-haskell >=2.11  && <2.23,
                        containers       >=0.4   && <0.8
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Unfortunately, it is no longer possible to reasonably test versions of GHC prior to 8.0 on modern versions of Linux, macOS, or Windows, as these versions of GHC all run into subtle OS incompatibility issues. While we could leave all of the old, pre-8.0 code paths around in `th-abstraction`, this runs the risk of bitrotting very quickly. As such, I have opted to remove these code paths here. Given that GHC 7.10.3 was released nearly a decade ago, I believe that the risk of breaking anyone's workflows by doing this is very minimal.

(It's somewhat unfortunate that we have to drop compatibility like this in a compatibility-oriented library like `th-abstraction`, but so be it.)