### PR TITLE
Use `TemplateHaskellQuotes` to define `eqTypeName` where possible, allow building with GHC 9.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,14 +8,15 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250216
+# version: 0.19.20250917
 #
-# REGENDATA ("0.19.20250216",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.19.20250917",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
   - push
   - pull_request
+  - merge_group
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -28,14 +29,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.1
+          - compiler: ghc-9.12.2
             compilerKind: ghc
-            compilerVersion: 9.12.1
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.10.3
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -43,9 +44,9 @@ jobs:
             compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -102,12 +103,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -183,7 +184,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -208,7 +209,11 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_th_abstraction}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package th-abstraction" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package th-abstraction" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package th-abstraction" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(th-abstraction)$/; }' >> cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -29,6 +29,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250908
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250908
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -123,6 +128,21 @@ jobs:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -133,7 +153,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -161,6 +181,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -216,6 +248,9 @@ jobs:
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(th-abstraction)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for th-abstraction
 
+## next -- ????.??.??
+* Support GHC 9.14.
+
 ## 0.7.1.0 -- 2024.12.05
 * Drop support for pre-8.0 versions of GHC.
 

--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -21,10 +21,10 @@ module Language.Haskell.TH.Datatype.Internal where
 import Language.Haskell.TH.Syntax
 
 eqTypeName :: Name
-#if !(MIN_VERSION_base(4,13,0))
-eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"
-#else
+#if MIN_VERSION_base(4,13,0)
 eqTypeName = mkNameG_tc "ghc-prim" "GHC.Types" "~"
+#else
+eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"
 #endif
 
 -- This is only needed for GHC 7.6-specific bug

--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 
 #if MIN_VERSION_template_haskell(2,12,0)
 {-# Language Safe #-}
@@ -20,9 +21,13 @@ module Language.Haskell.TH.Datatype.Internal where
 
 import Language.Haskell.TH.Syntax
 
+#if MIN_VERSION_base(4,13,0)
+import Data.Type.Equality
+#endif
+
 eqTypeName :: Name
 #if MIN_VERSION_base(4,13,0)
-eqTypeName = mkNameG_tc "ghc-prim" "GHC.Types" "~"
+eqTypeName = ''(~)
 #else
 eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"
 #endif

--- a/src/Language/Haskell/TH/Datatype/Internal.hs
+++ b/src/Language/Haskell/TH/Datatype/Internal.hs
@@ -26,7 +26,3 @@ eqTypeName = mkNameG_tc "ghc-prim" "GHC.Types" "~"
 #else
 eqTypeName = mkNameG_tc "base" "Data.Type.Equality" "~"
 #endif
-
--- This is only needed for GHC 7.6-specific bug
-starKindName :: Name
-starKindName = mkNameG_tc "ghc-prim" "GHC.Prim" "*"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1064,6 +1064,8 @@ polyKindedExTyvarTest =
            -> unless (a1 == a2) $
                 fail $ "Two occurrences of the same variable have different names: "
                     ++ show [a1, a2]
+         _ -> fail $ "Unexpected DatatypeInfo for T48: "
+                    ++ show info
        [| return () |]
    )
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,6 +17,9 @@
 {-# LANGUAGE UnliftedDatatypes #-}
 #endif
 
+-- We should aim to enable -Wincomplete-uni-patterns long-term. See #121.
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 {-|
 Module      : Main
 Description : Test cases for the th-abstraction package

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -14,6 +14,9 @@
 {-# Language TypeData #-}
 #endif
 
+-- We should aim to enable -Wincomplete-uni-patterns long-term. See #121.
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 {-|
 Module      : Types
 Description : Test cases for the th-abstraction package

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -28,7 +28,6 @@ library
                        Language.Haskell.TH.Datatype.TyVarBndr
   other-modules:       Language.Haskell.TH.Datatype.Internal
   build-depends:       base             >=4.9   && <5,
-                       ghc-prim,
                        template-haskell >=2.11  && <2.24,
                        containers       >=0.4   && <0.9
   hs-source-dirs:      src

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -17,7 +17,7 @@ category:            Development
 build-type:          Simple
 extra-source-files:  ChangeLog.md README.md
 cabal-version:       >=1.10
-tested-with:         GHC==9.12.1, GHC==9.10.1, GHC==9.8.4, GHC==9.6.6, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
+tested-with:         GHC==9.12.2, GHC==9.10.3, GHC==9.8.4, GHC==9.6.7, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
 
 source-repository head
   type: git

--- a/th-abstraction.cabal
+++ b/th-abstraction.cabal
@@ -17,7 +17,7 @@ category:            Development
 build-type:          Simple
 extra-source-files:  ChangeLog.md README.md
 cabal-version:       >=1.10
-tested-with:         GHC==9.12.2, GHC==9.10.3, GHC==9.8.4, GHC==9.6.7, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
+tested-with:         GHC==9.14.1, GHC==9.12.2, GHC==9.10.3, GHC==9.8.4, GHC==9.6.7, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2, GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
 
 source-repository head
   type: git
@@ -28,7 +28,7 @@ library
                        Language.Haskell.TH.Datatype.TyVarBndr
   other-modules:       Language.Haskell.TH.Datatype.Internal
   build-depends:       base             >=4.9   && <5,
-                       template-haskell >=2.11  && <2.24,
+                       template-haskell >=2.11  && <2.25,
                        containers       >=0.4   && <0.9
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This ensures that we always import the `(~)` type operator from the correct place and do not have to constantly keep its definition in sync whenever the internals change (see https://github.com/glguy/th-abstraction/issues/120 for an instance of such a thing happening). Fixes https://github.com/glguy/th-abstraction/issues/120.

This also updates the `.cabal` file to allow building with GHC 9.14 and regenerates the CI accordingly. In order to support a newer version of `haskell-ci`, I needed to disable `-Wincomplete-uni-patterns` in the test suite (see #121).